### PR TITLE
bugfix and documentation update

### DIFF
--- a/README
+++ b/README
@@ -36,6 +36,11 @@ Requirment
 7. libpcre
 8. net-snmp-5.x 
 
+In debian/ubuntu, the dependencies can be resolved by installing
+
+```
+sudo apt-get install libnl-dev libcrypto++-dev libpcre3-dev libpq-dev libsnmp-dev build-essential
+```
 
 Compilation and instalation
 -----------

--- a/README
+++ b/README
@@ -37,10 +37,8 @@ Requirment
 8. net-snmp-5.x 
 
 In debian/ubuntu, the dependencies can be resolved by installing
+ sudo apt-get install libnl-dev libcrypto++-dev libpcre3-dev libpq-dev libsnmp-dev build-essential
 
-```
-sudo apt-get install libnl-dev libcrypto++-dev libpcre3-dev libpq-dev libsnmp-dev build-essential
-```
 
 Compilation and instalation
 -----------

--- a/accel-pppd/logs/log_pgsql.c
+++ b/accel-pppd/logs/log_pgsql.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 
 #include <postgresql/libpq-fe.h>
 


### PR DESCRIPTION
1. Documentation update: Debian dependencies added
2. Fix missing ‘socklen_t’ reference:

```
Scanning dependencies of target log_pgsql
[ 72%] Building C object accel-pppd/logs/CMakeFiles/log_pgsql.dir/log_pgsql.c.o
In file included from /home/vagrant/wisp/builds/accel-ppp/accel-pppd/include/ap_session.h:4:0,
                 from /home/vagrant/wisp/builds/accel-ppp/accel-pppd/logs/log_pgsql.c:11:
/home/vagrant/wisp/builds/accel-ppp/accel-pppd/include/ap_net.h:6:52: error: unknown type name ‘socklen_t’
  int (*connect)(int sock, const struct sockaddr *, socklen_t len);
                                                    ^
/home/vagrant/wisp/builds/accel-ppp/accel-pppd/include/ap_net.h:7:49: error: unknown type name ‘socklen_t’
  int (*bind)(int sock, const struct sockaddr *, socklen_t len);
                                                 ^
/home/vagrant/wisp/builds/accel-ppp/accel-pppd/include/ap_net.h:10:93: error: unknown type name ‘socklen_t’
  ssize_t (*recvfrom)(int sock, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen);
                                                                                             ^
/home/vagrant/wisp/builds/accel-ppp/accel-pppd/include/ap_net.h:12:104: error: unknown type name ‘socklen_t’
  ssize_t (*sendto)(int sock, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr, socklen_t addrlen);
                                                                                                        ^
/home/vagrant/wisp/builds/accel-ppp/accel-pppd/include/ap_net.h:14:76: error: unknown type name ‘socklen_t’
  int (*setsockopt)(int sockfd, int level, int optname, const void *optval, socklen_t optlen);
                                                                            ^
make[2]: *** [accel-pppd/logs/CMakeFiles/log_pgsql.dir/log_pgsql.c.o] Error 1
make[1]: *** [accel-pppd/logs/CMakeFiles/log_pgsql.dir/all] Error 2
make: *** [all] Error 2
```
