### PR TITLE
add bypass subnets feature to ipoe

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -354,6 +354,9 @@ The
 .B proxy-arp
 parameter specifies whether accel-ppp should reply to arp requests.
 .TP
+.BI "bypass-net=" x.x.x.x/mask
+Specifies networks to which packets will be bypassed and therefore automatically allowed without session creation.
+TP
 .BI "local-net=" x.x.x.x/mask
 Specifies networks from which packets will be treated as unclassified. You may specify multiple local-net options.
 .TP

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -356,7 +356,7 @@ parameter specifies whether accel-ppp should reply to arp requests.
 .TP
 .BI "bypass-net=" x.x.x.x/mask
 Specifies networks to which packets will be bypassed and therefore automatically allowed without session creation.
-TP
+.TP
 .BI "local-net=" x.x.x.x/mask
 Specifies networks from which packets will be treated as unclassified. You may specify multiple local-net options.
 .TP

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -570,7 +570,7 @@ static void auth_result(struct ipoe_session *ses, int r)
 	ap_session_set_username(&ses->ses, username);
 	log_ppp_info1("%s: authentication succeeded\n", ses->ses.username);
 
-	cont:
+cont:
 	triton_event_fire(EV_SES_AUTHORIZED, &ses->ses);
 
 	if (ses->serv->opt_nat)
@@ -1678,7 +1678,7 @@ static void __ipoe_recv_dhcpv4(struct dhcpv4_serv *dhcpv4, struct dhcpv4_packet 
 		}
 	}
 
-	out:
+out:
 	pthread_mutex_unlock(&serv->lock);
 }
 
@@ -2672,9 +2672,9 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 
 	return;
 
-	parse_err:
+parse_err:
 	log_error("ipoe: failed to parse '%s'\n", opt);
-	out_err:
+out_err:
 	_free(str0);
 }
 
@@ -2819,7 +2819,7 @@ static void parse_local_net(const char *opt)
 
 	return;
 
-	out_err:
+out_err:
 	log_error("ipoe: failed to parse 'local-net=%s'\n", opt);
 }
 
@@ -3035,7 +3035,7 @@ int parse_offer_delay(const char *str)
 	_free(str1);
 	return 0;
 
-	out_err:
+out_err:
 	_free(str1);
 	log_error("ipoe: failed to parse offer-delay\n");
 	return -1;
@@ -3089,7 +3089,7 @@ static int parse_vlan_mon(const char *opt, long *mask)
 
 	return 0;
 
-	out_err:
+out_err:
 	log_error("ipoe: vlan-mon=%s: failed to parse\n", opt);
 	return -1;
 }

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -570,7 +570,7 @@ static void auth_result(struct ipoe_session *ses, int r)
 	ap_session_set_username(&ses->ses, username);
 	log_ppp_info1("%s: authentication succeeded\n", ses->ses.username);
 
-cont:
+	cont:
 	triton_event_fire(EV_SES_AUTHORIZED, &ses->ses);
 
 	if (ses->serv->opt_nat)
@@ -1250,7 +1250,7 @@ static struct ipoe_session *ipoe_session_create_dhcpv4(struct ipoe_serv *serv, s
 
 	ptr = ses->hwaddr;
 	sprintf(ses->ctrl.calling_station_id, "%02x:%02x:%02x:%02x:%02x:%02x",
-		ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5]);
+			ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5]);
 
 	ses->ses.ctrl = &ses->ctrl;
 	ses->ses.chan_name = ses->ctrl.calling_station_id;
@@ -1438,7 +1438,7 @@ static void ipoe_serv_disc_timer(struct triton_timer_t *t)
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 
 	while (!list_empty(&serv->disc_list)) {
-	  d = list_entry(serv->disc_list.next, typeof(*d), entry);
+		d = list_entry(serv->disc_list.next, typeof(*d), entry);
 
 		delay = (ts.tv_sec - d->ts.tv_sec) * 1000 + (ts.tv_nsec - d->ts.tv_nsec) / 1000000;
 		offer_delay = get_offer_delay();
@@ -1678,7 +1678,7 @@ static void __ipoe_recv_dhcpv4(struct dhcpv4_serv *dhcpv4, struct dhcpv4_packet 
 		}
 	}
 
-out:
+	out:
 	pthread_mutex_unlock(&serv->lock);
 }
 
@@ -2469,7 +2469,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 				if (strcmp(ptr1, "ifname") == 0)
 					opt_username = USERNAME_IFNAME;
 #ifdef USE_LUA
-				else if (strlen(ptr1) > 4 && memcmp(ptr1, "lua:", 4) == 0) {
+					else if (strlen(ptr1) > 4 && memcmp(ptr1, "lua:", 4) == 0) {
 					opt_username = USERNAME_LUA;
 					opt_lua_username_func = _strdup(ptr1 + 4);
 				}
@@ -2539,7 +2539,7 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 		}
 
 		if (serv->dhcpv4_relay &&
-				(serv->dhcpv4_relay->addr != relay_addr || serv->dhcpv4_relay->giaddr != opt_giaddr)) {
+			(serv->dhcpv4_relay->addr != relay_addr || serv->dhcpv4_relay->giaddr != opt_giaddr)) {
 			if (serv->opt_ifcfg)
 				ipoe_serv_del_addr(serv, serv->dhcpv4_relay->giaddr, 0);
 			dhcpv4_relay_free(serv->dhcpv4_relay, &serv->ctx);
@@ -2672,9 +2672,9 @@ static void add_interface(const char *ifname, int ifindex, const char *opt, int 
 
 	return;
 
-parse_err:
+	parse_err:
 	log_error("ipoe: failed to parse '%s'\n", opt);
-out_err:
+	out_err:
 	_free(str0);
 }
 
@@ -2768,7 +2768,7 @@ static void load_interfaces(struct conf_sect_t *sect)
 	ipoe_nl_delete_interfaces();
 
 	list_for_each_entry(serv, &serv_list, entry)
-		serv->active = 0;
+	serv->active = 0;
 
 	list_for_each_entry(opt, &sect->items, entry) {
 		if (strcmp(opt->name, "interface"))
@@ -2819,8 +2819,41 @@ static void parse_local_net(const char *opt)
 
 	return;
 
-out_err:
+	out_err:
 	log_error("ipoe: failed to parse 'local-net=%s'\n", opt);
+}
+
+static void parse_bypass_net(const char *opt)
+{
+	const char *ptr;
+	char str[17];
+	in_addr_t addr;
+	int mask;
+	char *endptr;
+
+	ptr = strchr(opt, '/');
+	if (ptr) {
+		memcpy(str, opt, ptr - opt);
+		str[ptr - opt] = 0;
+		addr = inet_addr(str);
+		if (addr == INADDR_NONE)
+			goto out_err;
+		mask = strtoul(ptr + 1, &endptr, 10);
+		if (mask > 32)
+			goto out_err;
+	} else {
+		addr = inet_addr(opt);
+		if (addr == INADDR_NONE)
+			goto out_err;
+		mask = 24;
+	}
+
+	ipoe_nl_add_bypass_net(addr, mask);
+
+	return;
+
+	out_err:
+	log_error("ipoe: failed to parse 'bypass-net=%s'\n", opt);
 }
 
 static void load_local_nets(struct conf_sect_t *sect)
@@ -2835,6 +2868,21 @@ static void load_local_nets(struct conf_sect_t *sect)
 		if (!opt->val)
 			continue;
 		parse_local_net(opt->val);
+	}
+}
+
+static void load_bypass_nets(struct conf_sect_t *sect)
+{
+	struct conf_option_t *opt;
+
+	ipoe_nl_delete_bypass_nets();
+
+	list_for_each_entry(opt, &sect->items, entry) {
+		if (strcmp(opt->name, "bypass-net"))
+			continue;
+		if (!opt->val)
+			continue;
+		parse_bypass_net(opt->val);
 	}
 }
 
@@ -2987,7 +3035,7 @@ int parse_offer_delay(const char *str)
 	_free(str1);
 	return 0;
 
-out_err:
+	out_err:
 	_free(str1);
 	log_error("ipoe: failed to parse offer-delay\n");
 	return -1;
@@ -3041,7 +3089,7 @@ static int parse_vlan_mon(const char *opt, long *mask)
 
 	return 0;
 
-out_err:
+	out_err:
 	log_error("ipoe: vlan-mon=%s: failed to parse\n", opt);
 	return -1;
 }
@@ -3193,7 +3241,7 @@ static void load_config(void)
 		if (strcmp(opt, "ifname") == 0)
 			conf_username = USERNAME_IFNAME;
 #ifdef USE_LUA
-		else if (strlen(opt) > 4 && memcmp(opt, "lua:", 4) == 0) {
+			else if (strlen(opt) > 4 && memcmp(opt, "lua:", 4) == 0) {
 			conf_username = USERNAME_LUA;
 			conf_lua_username_func = opt + 4;
 		}
@@ -3438,16 +3486,17 @@ static void load_config(void)
 
 	load_interfaces(s);
 	load_local_nets(s);
+	load_bypass_nets(s);
 	load_vlan_mon(s);
 	load_gw_addr(s);
 }
 
 static struct triton_context_t l4_redirect_ctx = {
-	.close = l4_redirect_ctx_close,
+		.close = l4_redirect_ctx_close,
 };
 
 static struct triton_timer_t l4_redirect_timer = {
-	.expire = l4_redirect_list_timer,
+		.expire = l4_redirect_list_timer,
 };
 
 static void ipoe_init(void)

--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -123,6 +123,8 @@ struct ipoe_serv *ipoe_find_serv(const char *ifname);
 
 void ipoe_nl_add_net(uint32_t addr, int mask);
 void ipoe_nl_delete_nets(void);
+void ipoe_nl_add_bypass_net(uint32_t addr, int mask);
+void ipoe_nl_delete_bypass_nets(void);
 void ipoe_nl_add_interface(int ifindex);
 void ipoe_nl_delete_interfaces(void);
 int ipoe_nl_create(uint32_t peer_addr, uint32_t addr, const char *ifname, uint8_t *hwaddr);

--- a/accel-pppd/ctrl/ipoe/ipoe_netlink.c
+++ b/accel-pppd/ctrl/ipoe/ipoe_netlink.c
@@ -84,6 +84,61 @@ void ipoe_nl_add_net(uint32_t addr, int mask)
 		log_error("ipoe: nl_add_net: error talking to kernel\n");
 }
 
+void ipoe_nl_delete_bypass_nets(void)
+{
+	struct nlmsghdr *nlh;
+	struct genlmsghdr *ghdr;
+	struct {
+		struct nlmsghdr n;
+		char buf[1024];
+	} req;
+
+	if (rth.fd == -1)
+		return;
+
+	nlh = &req.n;
+	nlh->nlmsg_len = NLMSG_LENGTH(GENL_HDRLEN);
+	nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+	nlh->nlmsg_type = ipoe_genl_id;
+
+	ghdr = NLMSG_DATA(&req.n);
+	ghdr->cmd = IPOE_CMD_DEL_BYPASS_NET;
+
+	addattr32(nlh, 1024, IPOE_ATTR_ADDR, 0);
+
+	if (rtnl_talk(&rth, nlh, 0, 0, nlh, NULL, NULL, 0) < 0 )
+		log_error("ipoe: nl_del_net: error talking to kernel\n");
+}
+
+void ipoe_nl_add_bypass_net(uint32_t addr, int mask)
+{
+	struct nlmsghdr *nlh;
+	struct genlmsghdr *ghdr;
+	struct {
+		struct nlmsghdr n;
+		char buf[1024];
+	} req;
+
+	if (rth.fd == -1)
+		return;
+
+	nlh = &req.n;
+	nlh->nlmsg_len = NLMSG_LENGTH(GENL_HDRLEN);
+	nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+	nlh->nlmsg_type = ipoe_genl_id;
+
+	ghdr = NLMSG_DATA(&req.n);
+	ghdr->cmd = IPOE_CMD_ADD_BYPASS_NET;
+
+	mask = ((1 << mask) - 1) << (32 - mask);
+
+	addattr32(nlh, 1024, IPOE_ATTR_ADDR, addr);
+	addattr32(nlh, 1024, IPOE_ATTR_MASK, mask);
+
+	if (rtnl_talk(&rth, nlh, 0, 0, nlh, NULL, NULL, 0) < 0 )
+		log_error("ipoe: nl_add_bypass_net: error talking to kernel\n");
+}
+
 int ipoe_nl_add_exclude(uint32_t addr, int mask)
 {
 	struct rtnl_handle rth;
@@ -282,7 +337,7 @@ int ipoe_nl_create(uint32_t peer_addr, uint32_t addr, const char *ifname, uint8_
 
 	ret = *(uint32_t *)(RTA_DATA(tb[IPOE_ATTR_IFINDEX]));
 
-out:
+	out:
 	rtnl_close(&rth);
 
 	return ret;
@@ -632,10 +687,10 @@ static int ipoe_mc_read(struct triton_md_handler_t *h)
 	struct sockaddr_nl nladdr;
 	struct iovec iov;
 	struct msghdr msg = {
-		.msg_name = &nladdr,
-		.msg_namelen = sizeof(nladdr),
-		.msg_iov = &iov,
-		.msg_iovlen = 1,
+			.msg_name = &nladdr,
+			.msg_namelen = sizeof(nladdr),
+			.msg_iov = &iov,
+			.msg_iovlen = 1,
 	};
 	char   buf[8192];
 
@@ -713,11 +768,11 @@ static void ipoe_mc_close(struct triton_context_t *ctx)
 }
 
 static struct triton_context_t mc_ctx = {
-	.close = ipoe_mc_close,
+		.close = ipoe_mc_close,
 };
 
 static struct triton_md_handler_t mc_hnd = {
-	.read = ipoe_mc_read,
+		.read = ipoe_mc_read,
 };
 
 static void init(void)

--- a/accel-pppd/ctrl/ipoe/ipoe_netlink.c
+++ b/accel-pppd/ctrl/ipoe/ipoe_netlink.c
@@ -75,7 +75,7 @@ void ipoe_nl_add_net(uint32_t addr, int mask)
 	ghdr = NLMSG_DATA(&req.n);
 	ghdr->cmd = IPOE_CMD_ADD_NET;
 
-	mask = ((1 << mask) - 1) << (32 - mask);
+	mask = (0xffffffff) << (32 - mask);
 
 	addattr32(nlh, 1024, IPOE_ATTR_ADDR, addr);
 	addattr32(nlh, 1024, IPOE_ATTR_MASK, mask);
@@ -130,7 +130,7 @@ void ipoe_nl_add_bypass_net(uint32_t addr, int mask)
 	ghdr = NLMSG_DATA(&req.n);
 	ghdr->cmd = IPOE_CMD_ADD_BYPASS_NET;
 
-	mask = ((1 << mask) - 1) << (32 - mask);
+	mask = (0xffffffff) << (32 - mask);
 
 	addattr32(nlh, 1024, IPOE_ATTR_ADDR, addr);
 	addattr32(nlh, 1024, IPOE_ATTR_MASK, mask);

--- a/accel-pppd/ctrl/ipoe/ipoe_netlink.c
+++ b/accel-pppd/ctrl/ipoe/ipoe_netlink.c
@@ -337,7 +337,7 @@ int ipoe_nl_create(uint32_t peer_addr, uint32_t addr, const char *ifname, uint8_
 
 	ret = *(uint32_t *)(RTA_DATA(tb[IPOE_ATTR_IFINDEX]));
 
-	out:
+out:
 	rtnl_close(&rth);
 
 	return ret;

--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -646,7 +646,7 @@ static int pptp_connect(struct triton_md_handler_t *h)
 		log_info2("pptp: new connection from %s\n", inet_ntoa(addr.sin_addr));
 
 		if (iprange_client_check(addr.sin_addr.s_addr)) {
-			log_warn("pptp: IP is out of client-ip-range, droping connection...\n");
+			log_warn("pptp: IP %s is out of client-ip-range, droping connection...\n", inet_ntoa(addr.sin_addr));
 			close(sock);
 			continue;
 		}

--- a/drivers/ipoe/ipoe.c
+++ b/drivers/ipoe/ipoe.c
@@ -832,14 +832,14 @@ static unsigned int ipt_in_hook(const struct nf_hook_ops *ops, struct sk_buff *s
 		if (!ipoe_check_network(iph->saddr))
 			return NF_ACCEPT;
 
-		if(ipoe_check_bypass(iph->daddr))
-			return NF_ACCEPT;
-
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,1,0)
 		if (!ipoe_check_interface(in->ifindex))
 #else
 		if (!ipoe_check_interface(state->in->ifindex))
 #endif
+			return NF_ACCEPT;
+
+		if(ipoe_check_bypass(iph->daddr))
 			return NF_ACCEPT;
 
 		ipoe_queue_u(skb, iph->saddr);

--- a/drivers/ipoe/ipoe.c
+++ b/drivers/ipoe/ipoe.c
@@ -576,7 +576,7 @@ static netdev_tx_t ipoe_xmit(struct sk_buff *skb, struct net_device *dev)
 
 		return NETDEV_TX_OK;
 	}
-	drop:
+drop:
 	stats->tx_dropped++;
 	dev_kfree_skb(skb);
 	return NETDEV_TX_OK;
@@ -723,7 +723,7 @@ static void ipoe_process_queue(struct work_struct *w)
 				kfree_skb(skb);
 				continue;
 
-				nl_err:
+nl_err:
 				nlmsg_free(report_skb);
 				report_skb = NULL;
 			}
@@ -821,7 +821,7 @@ static unsigned int ipt_in_hook(const struct nf_hook_ops *ops, struct sk_buff *s
 	if (!iph->saddr)
 		return NF_ACCEPT;
 
-	// pr_info("ipoe: recv %08x %08x\n", iph->saddr, iph->daddr);
+	//pr_info("ipoe: recv %08x %08x\n", iph->saddr, iph->daddr);
 
 	ses = ipoe_lookup(iph->saddr);
 
@@ -898,7 +898,7 @@ static unsigned int ipt_in_hook(const struct nf_hook_ops *ops, struct sk_buff *s
 	stats->rx_bytes += skb->len;
 #endif
 
-	out:
+out:
 	atomic_dec(&ses->refs);
 	return ret;
 }
@@ -1010,7 +1010,7 @@ static int vlan_pt_recv(struct sk_buff *skb, struct net_device *dev, struct pack
 
 	schedule_work(&vlan_notify_work);
 
-	out:
+out:
 	kfree_skb(skb);
 	return 0;
 }
@@ -1293,9 +1293,9 @@ static int ipoe_create(__be32 peer_addr, __be32 addr, const char *link_ifname, c
 
 	return r;
 
-	failed_free:
+failed_free:
 	free_netdev(dev);
-	failed:
+failed:
 	if (link_dev)
 		dev_put(link_dev);
 	return r;
@@ -1334,10 +1334,10 @@ static int ipoe_nl_cmd_noop(struct sk_buff *skb, struct genl_info *info)
 	return genlmsg_unicast(genl_info_net(info), msg, info->snd_portid);
 #endif
 
-	err_out:
+err_out:
 	nlmsg_free(msg);
 
-	out:
+out:
 	return ret;
 }
 
@@ -1411,10 +1411,10 @@ static int ipoe_nl_cmd_create(struct sk_buff *skb, struct genl_info *info)
 	return genlmsg_unicast(genl_info_net(info), msg, info->snd_portid);
 #endif
 
-	err_out:
+err_out:
 	nlmsg_free(msg);
 
-	out:
+out:
 	return ret;
 }
 
@@ -1473,7 +1473,7 @@ static int ipoe_nl_cmd_delete(struct sk_buff *skb, struct genl_info *info)
 
 	ret = 0;
 
-	out_unlock:
+out_unlock:
 	up(&ipoe_wlock);
 	return ret;
 }
@@ -1586,7 +1586,7 @@ static int ipoe_nl_cmd_modify(struct sk_buff *skb, struct genl_info *info)
 
 	ret = 0;
 
-	out_unlock:
+out_unlock:
 	up(&ipoe_wlock);
 	return ret;
 }
@@ -1611,7 +1611,7 @@ static int fill_info(struct sk_buff *skb, struct ipoe_session *ses, u32 pid, u32
 	return genlmsg_end(skb, hdr);
 #endif
 
-	nla_put_failure:
+nla_put_failure:
 	genlmsg_cancel(skb, hdr);
 	return -EMSGSIZE;
 }
@@ -2311,9 +2311,9 @@ static int __init ipoe_init(void)
 
 	return 0;
 
-	out_unreg:
+out_unreg:
 	genl_unregister_family(&ipoe_nl_family);
-	out:
+out:
 	return err;
 }
 

--- a/drivers/ipoe/ipoe.h
+++ b/drivers/ipoe/ipoe.h
@@ -11,6 +11,8 @@ enum {
 	IPOE_CMD_GET,
 	IPOE_CMD_ADD_NET,
 	IPOE_CMD_DEL_NET,
+	IPOE_CMD_ADD_BYPASS_NET,
+	IPOE_CMD_DEL_BYPASS_NET,
 	IPOE_CMD_ADD_IF,
 	IPOE_CMD_DEL_IF,
 	IPOE_CMD_ADD_VLAN_MON,
@@ -23,30 +25,29 @@ enum {
 	__IPOE_CMD_MAX,
 };
 
-#define IPOE_CMD_MAX			(__IPOE_CMD_MAX - 1)
+#define IPOE_CMD_MAX		(__IPOE_CMD_MAX - 1)
 
 enum {
-	IPOE_ATTR_NONE,			 /* no data */
-	IPOE_ATTR_ADDR,		   /* u32 */
-	IPOE_ATTR_PEER_ADDR,	 /* u32 */
-	IPOE_ATTR_IFNAME,	   /* u32 */
-	IPOE_ATTR_HWADDR,	   /* u32 */
-	IPOE_ATTR_MASK,	   /* u32 */
-	IPOE_ATTR_IFINDEX,	   /* u32 */
-	IPOE_ATTR_ETH_HDR,	   /* u32 */
-	IPOE_ATTR_IP_HDR,	   /* u32 */
-	IPOE_ATTR_VLAN_MASK,	   /* u32 */
+	IPOE_ATTR_NONE,			/* no data */
+	IPOE_ATTR_ADDR,			/* u32 */
+	IPOE_ATTR_PEER_ADDR,	/* u32 */
+	IPOE_ATTR_IFNAME,		/* u32 */
+	IPOE_ATTR_HWADDR,		/* u32 */
+	IPOE_ATTR_MASK,			/* u32 */
+	IPOE_ATTR_IFINDEX,		/* u32 */
+	IPOE_ATTR_ETH_HDR,		/* u32 */
+	IPOE_ATTR_IP_HDR,		/* u32 */
+	IPOE_ATTR_VLAN_MASK,	/* u32 */
 	__IPOE_ATTR_MAX,
 };
 
-#define IPOE_ATTR_MAX			(__IPOE_ATTR_MAX - 1)
+#define IPOE_ATTR_MAX		(__IPOE_ATTR_MAX - 1)
 
 /*
  * NETLINK_GENERIC related info
  */
-#define IPOE_GENL_NAME		  "IPoE"
-#define IPOE_GENL_MCG_PKT		"Packet"
-#define IPOE_GENL_VERSION	  0x1
+#define IPOE_GENL_NAME		"IPoE"
+#define IPOE_GENL_MCG_PKT	"Packet"
+#define IPOE_GENL_VERSION	0x1
 
 #endif
-


### PR DESCRIPTION
Proposed changes implies _bypass-net=x.x.x.x/mask_ parameter which allows to pass traffic to selected destinations without creating user sessions. Useful to avoid uneccessary sessions creation in L3 mode when customer should have free access to services deployed on access server, some internet resources, etc

p.s. it seems I got some identation issues due to tab/space, - not sure how to fix them (or either should they be fixed or not)
