### PR TITLE
Multiple service-name, compatibility with old accel-ppp with service name specified

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -478,6 +478,10 @@ Specifies AC-Name tag value. If absent tag will not be sent.
 .BI "service-name=" service-name
 Specifies Service-Name to respond. If absent any Service-Name is acceptable and client's Service-Name will be sent back.
 .TP
+.BI "accept-any-service=" n
+If service-name specified still will answer with service names, but accepts any service name in PADR request. Useful 
+for scenarios, where selection of PPPoE done by client, based on service names in PADO.
+.TP
 .BI "pado-delay=" delay[,delay1:count1[,delay2:count2[,...]]]
 Specifies delays (also in condition of connection count) to send PADO (ms).
 Last delay in list may be -1 which means don't accept new connections.

--- a/accel-pppd/ctrl/pppoe/cli.c
+++ b/accel-pppd/ctrl/pppoe/cli.c
@@ -170,9 +170,15 @@ static int show_service_name_exec(const char *cmd, char * const *f, int f_cnt, v
 	if (f_cnt != 3)
 		return CLI_CMD_SYNTAX;
 
-	if (conf_service_name)
-		cli_sendv(cli, "%s\r\n", conf_service_name);
-	else
+	if (conf_service_name[0]) {
+		int i = 0;
+		do {
+		    cli_sendv(cli, "%s", conf_service_name[i]);
+		    i++;
+		    if (conf_service_name[i]) { cli_sendv(cli, ","); }
+		} while(conf_service_name[i]);
+		cli_sendv(cli, "\r\n");
+	} else
 		cli_sendv(cli, "*\r\n");
 
 	return CLI_CMD_OK;
@@ -219,13 +225,27 @@ static int set_service_name_exec(const char *cmd, char * const *f, int f_cnt, vo
 	if (f_cnt != 4)
 		return CLI_CMD_SYNTAX;
 
-	if (conf_service_name)
-		_free(conf_service_name);
-
+	if (conf_service_name[0]) {
+		int i = 0;
+		do {
+		    _free(conf_service_name[i]);
+		    i++;
+		} while(conf_service_name[i]);
+		conf_service_name[0] = NULL;
+	}
 	if (!strcmp(f[3], "*"))
-		conf_service_name = NULL;
-	else
-		conf_service_name = _strdup(f[3]);
+		conf_service_name[0] = NULL;
+	else {
+	    char *conf_service_name_string = _strdup(f[3]);
+	    char *p = strtok (conf_service_name_string, ",");
+	    int i = 0;
+	    while (p != NULL && i<255) {
+		conf_service_name[i++] = _strdup(p);
+		p = strtok(NULL, ",");
+	    }
+	    conf_service_name[i] = NULL;
+	    _free(conf_service_name_string);
+	}
 
 	return CLI_CMD_OK;
 }

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -88,7 +88,8 @@ struct iplink_arg {
 };
 
 int conf_verbose;
-char *conf_service_name;
+char *conf_service_name[255];
+int conf_accept_any_service;
 char *conf_ac_name;
 int conf_ifname_in_sid;
 char *conf_pado_delay;
@@ -758,8 +759,13 @@ static void pppoe_send_PADO(struct pppoe_serv_t *serv, const uint8_t *addr, cons
 	setup_header(pack, serv->hwaddr, addr, CODE_PADO, 0);
 
 	add_tag(pack, TAG_AC_NAME, (uint8_t *)conf_ac_name, strlen(conf_ac_name));
-	if (conf_service_name)
-		add_tag(pack, TAG_SERVICE_NAME, (uint8_t *)conf_service_name, strlen(conf_service_name));
+	if (conf_service_name[0]) {
+		int i = 0;
+		do {
+		    add_tag(pack, TAG_SERVICE_NAME, (uint8_t *)conf_service_name, strlen(conf_service_name[i]));
+		    i++;
+		} while(conf_service_name[i]);
+	}
 
 	if (service_name)
 		add_tag2(pack, service_name);
@@ -939,7 +945,7 @@ static void pppoe_recv_PADI(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 	struct pppoe_tag *host_uniq_tag = NULL;
 	struct pppoe_tag *relay_sid_tag = NULL;
 	struct pppoe_tag *service_name_tag = NULL;
-	int len, n, service_match = conf_service_name == NULL;
+	int len, n, service_match = conf_service_name[0] == NULL;
 	struct delayed_pado_t *pado;
 	struct timespec ts;
 	uint16_t ppp_max_payload = 0;
@@ -973,12 +979,16 @@ static void pppoe_recv_PADI(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 			case TAG_END_OF_LIST:
 				break;
 			case TAG_SERVICE_NAME:
-				if (conf_service_name) {
-					if (ntohs(tag->tag_len) != strlen(conf_service_name))
-						break;
-					if (memcmp(tag->tag_data, conf_service_name, ntohs(tag->tag_len)))
-						break;
-					service_match = 1;
+				if (conf_service_name[0]) {
+					int svc_index = 0;
+					do {
+					    if (ntohs(tag->tag_len) == strlen(conf_service_name[svc_index]) && 
+						memcmp(tag->tag_data, conf_service_name[svc_index], ntohs(tag->tag_len)) == 0) {
+						    service_match = 1;
+						    break;
+					    }
+					    svc_index++;
+					} while(conf_service_name[svc_index]);
 				} else
 					service_name_tag = tag;
 				break;
@@ -998,7 +1008,7 @@ static void pppoe_recv_PADI(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 	if (conf_verbose)
 		print_packet(serv->ifname, "recv", pack);
 
-	if (!service_match) {
+	if (!service_match && !conf_accept_any_service) {
 		if (conf_verbose)
 			log_warn("pppoe: discarding PADI packet (Service-Name mismatch)\n");
 		return;
@@ -1103,12 +1113,16 @@ static void pppoe_recv_PADR(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 				service_name_tag = tag;
 				if (tag->tag_len == 0)
 					service_match = 1;
-				else if (conf_service_name) {
-					if (ntohs(tag->tag_len) != strlen(conf_service_name))
-						break;
-					if (memcmp(tag->tag_data, conf_service_name, ntohs(tag->tag_len)))
-						break;
-					service_match = 1;
+				else if (conf_service_name[0]) {
+					int svc_index = 0;
+					do {
+					    if (ntohs(tag->tag_len) == strlen(conf_service_name[svc_index]) && 
+						memcmp(tag->tag_data, conf_service_name[svc_index], ntohs(tag->tag_len)) == 0) {
+						    service_match = 1;
+						    break;
+					    }
+					    svc_index++;
+					} while(conf_service_name[svc_index]);
 				} else {
 					service_match = 1;
 				}
@@ -1154,7 +1168,7 @@ static void pppoe_recv_PADR(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 		return;
 	}
 
-	if (!service_match) {
+	if (!service_match && !conf_accept_any_service) {
 		if (conf_verbose)
 			log_warn("pppoe: Service-Name mismatch\n");
 		pppoe_send_err(serv, ethhdr->h_source, host_uniq_tag, relay_sid_tag, CODE_PADS, TAG_SERVICE_NAME_ERROR);
@@ -1883,6 +1897,10 @@ static void load_config(void)
 	if (opt)
 		conf_verbose = atoi(opt);
 
+	opt = conf_get_opt("pppoe", "accept-any-service");
+	if (opt)
+	    conf_accept_any_service = atoi(opt);
+
 	opt = conf_get_opt("pppoe", "ac-name");
 	if (!opt)
 		opt = conf_get_opt("pppoe", "AC-Name");
@@ -1897,9 +1915,23 @@ static void load_config(void)
 	if (!opt)
 		opt = conf_get_opt("pppoe", "Service-Name");
 	if (opt) {
-		if (conf_service_name)
-			_free(conf_service_name);
-		conf_service_name = _strdup(opt);
+		if (conf_service_name[0]) {
+			int i = 0;
+			do {
+			    _free(conf_service_name[i]);
+			    i++;
+			} while(conf_service_name[i]);
+			conf_service_name[0] = NULL;
+		}
+		char *conf_service_name_string = _strdup(opt);
+		char *p = strtok (conf_service_name_string, ",");
+		int i = 0;
+		while (p != NULL && i<255) {
+		    conf_service_name[i++] = _strdup(p);
+		    p = strtok(NULL, ",");
+		}
+		conf_service_name[i] = NULL;
+		_free(conf_service_name_string);
 	}
 
 	opt = conf_get_opt("pppoe", "ifname-in-sid");
@@ -2015,6 +2047,7 @@ static void pppoe_init(void)
 	conn_pool = mempool_create(sizeof(struct pppoe_conn_t));
 	pado_pool = mempool_create(sizeof(struct delayed_pado_t));
 	padi_pool = mempool_create(sizeof(struct padi_t));
+	conf_service_name[0] = NULL;
 
 	if (!conf_get_section("pppoe")) {
 		log_error("pppoe: no configuration, disabled...\n");

--- a/accel-pppd/ctrl/pppoe/pppoe.h
+++ b/accel-pppd/ctrl/pppoe/pppoe.h
@@ -102,7 +102,8 @@ struct pppoe_serv_t
 };
 
 extern int conf_verbose;
-extern char *conf_service_name;
+extern char *conf_service_name[255];
+extern int conf_accept_any_service;
 extern char *conf_ac_name;
 extern char *conf_pado_delay;
 


### PR DESCRIPTION
It is possible to specify multiple service names now (as in most pppoe daemons), old options are backward compatible.
Also new accel-ppp verifying if service-name specified, it should strictly match on PADI and PADR packets, while old version doesn't do that. It is usual ISP scenario, where some clients has service-name specified, and some are "default". Without this patch default without service-name wont be able to connect.