### PR TITLE
Adding blank service answer, adding back service to PADO and fix for 4.10

### DIFF
--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -90,6 +90,7 @@ struct iplink_arg {
 int conf_verbose;
 char *conf_service_name[255];
 int conf_accept_any_service;
+int conf_accept_blank_service;
 char *conf_ac_name;
 int conf_ifname_in_sid;
 char *conf_pado_delay;
@@ -755,6 +756,7 @@ static void pppoe_send_PADO(struct pppoe_serv_t *serv, const uint8_t *addr, cons
 {
 	uint8_t pack[ETHER_MAX_LEN];
 	uint8_t cookie[COOKIE_LENGTH];
+	uint8_t request_tag_added = 0;
 
 	setup_header(pack, serv->hwaddr, addr, CODE_PADO, 0);
 
@@ -763,11 +765,15 @@ static void pppoe_send_PADO(struct pppoe_serv_t *serv, const uint8_t *addr, cons
 		int i = 0;
 		do {
 		    add_tag(pack, TAG_SERVICE_NAME, (uint8_t *)conf_service_name[i], strlen(conf_service_name[i]));
+		    /* Avoid adding tag twice, mark if tag same as in service list */
+		    if (service_name && strlen(conf_service_name[i]) == service_name->tag_len && memcmp(service_name->tag_data, conf_service_name[i], service_name->tag_len) == 0)
+			request_tag_added = 1;
 		    i++;
 		} while(conf_service_name[i]);
 	}
 
-	if (service_name)
+	/* If tag not added yet before, then add it now */
+	if (service_name && !request_tag_added)
 		add_tag2(pack, service_name);
 
 	generate_cookie(serv, addr, cookie, host_uniq, relay_sid);
@@ -982,6 +988,10 @@ static void pppoe_recv_PADI(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 				if (conf_service_name[0]) {
 					int svc_index = 0;
 					do {
+					    if (ntohs(tag->tag_len) == 0 && conf_accept_blank_service) {
+						service_match = 1;
+						break;
+					    }
 					    if (ntohs(tag->tag_len) == strlen(conf_service_name[svc_index]) && 
 						memcmp(tag->tag_data, conf_service_name[svc_index], ntohs(tag->tag_len)) == 0) {
 						    service_match = 1;
@@ -989,8 +999,8 @@ static void pppoe_recv_PADI(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 					    }
 					    svc_index++;
 					} while(conf_service_name[svc_index]);
-				} else
-					service_name_tag = tag;
+				}
+				service_name_tag = tag;
 				break;
 			case TAG_HOST_UNIQ:
 				host_uniq_tag = tag;
@@ -1900,6 +1910,10 @@ static void load_config(void)
 	opt = conf_get_opt("pppoe", "accept-any-service");
 	if (opt)
 	    conf_accept_any_service = atoi(opt);
+
+	opt = conf_get_opt("pppoe", "accept-blank-service");
+	if (opt)
+	    conf_accept_blank_service = atoi(opt);
 
 	opt = conf_get_opt("pppoe", "ac-name");
 	if (!opt)

--- a/drivers/ipoe/ipoe.c
+++ b/drivers/ipoe/ipoe.c
@@ -1668,7 +1668,7 @@ static struct genl_ops ipoe_nl_ops[] = {
 };
 
 static struct genl_family ipoe_nl_family = {
-	.id		= GENL_ID_GENERATE,
+	.id		= 0,
 	.name		= IPOE_GENL_NAME,
 	.version	= IPOE_GENL_VERSION,
 	.hdrsize	= 0,

--- a/drivers/vlan_mon/vlan_mon.c
+++ b/drivers/vlan_mon/vlan_mon.c
@@ -660,7 +660,7 @@ static struct genl_ops vlan_mon_nl_ops[] = {
 };
 
 static struct genl_family vlan_mon_nl_family = {
-	.id		= GENL_ID_GENERATE,
+	.id		= 0,
 	.name		= VLAN_MON_GENL_NAME,
 	.version	= VLAN_MON_GENL_VERSION,
 	.hdrsize	= 0,

--- a/drivers/vlan_mon/vlan_mon.c
+++ b/drivers/vlan_mon/vlan_mon.c
@@ -659,6 +659,7 @@ static struct genl_ops vlan_mon_nl_ops[] = {
 	},
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 static struct genl_family vlan_mon_nl_family = {
 	.id		= 0,
 	.name		= VLAN_MON_GENL_NAME,
@@ -666,6 +667,20 @@ static struct genl_family vlan_mon_nl_family = {
 	.hdrsize	= 0,
 	.maxattr	= VLAN_MON_ATTR_MAX,
 };
+#else
+static struct genl_family vlan_mon_nl_family = {
+	.name		= VLAN_MON_GENL_NAME,
+	.version	= VLAN_MON_GENL_VERSION,
+	.maxattr	= VLAN_MON_ATTR_MAX,
+	.netnsok	= true,
+	.module		= THIS_MODULE,
+	.ops		= vlan_mon_nl_ops,
+	.n_ops		= ARRAY_SIZE(vlan_mon_nl_ops),
+	.mcgrps		= vlan_mon_nl_mcgrps,
+	.n_mcgrps	= ARRAY_SIZE(vlan_mon_nl_mcgrps),
+};
+#endif
+
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
 static struct genl_multicast_group vlan_mon_nl_mcg = {
@@ -695,8 +710,10 @@ static int __init vlan_mon_init(void)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,13,0)
 	err = genl_register_family_with_ops(&vlan_mon_nl_family, vlan_mon_nl_ops, ARRAY_SIZE(vlan_mon_nl_ops));
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 	err = genl_register_family_with_ops_groups(&vlan_mon_nl_family, vlan_mon_nl_ops, vlan_mon_nl_mcgs);
+#else
+	err = genl_register_family(&vlan_mon_nl_family);
 #endif
 	if (err < 0) {
 		printk(KERN_INFO "vlan_mon: can't register netlink interface\n");


### PR DESCRIPTION
1)Some PPPoE answer only blank service in PADI and predefined in config service names.
2)PADO should be RFC2516 compliant. Quoting "The PADO packet MUST contain one AC-Name TAG containing the Access  Concentrator's name, a Service-Name TAG identical to the one in the PADI, and any number of other Service-Name TAGs indicating other services that the Access Concentrator offers.", so we add in answer(PADO) service tag from PADI.
3)Fix for kernel 4.10, they broke userspace API, so might be better to use constant. Reference: https://patchwork.ozlabs.org/patch/734681/