### PR TITLE
pptp/l2tp: echo failure improvements

### DIFF
--- a/accel-pppd/ctrl/l2tp/l2tp.c
+++ b/accel-pppd/ctrl/l2tp/l2tp.c
@@ -3213,6 +3213,9 @@ static int l2tp_recv_HELLO(struct l2tp_conn_t *conn,
 
 	log_tunnel(log_debug, conn, "handling HELLO\n");
 
+	if (conn->hello_timer.tpd)
+		triton_timer_mod(&conn->hello_timer, 0);
+
 	return 0;
 }
 

--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -423,13 +423,10 @@ static int pptp_echo_rply(struct pptp_conn_t *conn)
 	if (conf_verbose)
 		log_ppp_debug("recv [PPTP Echo-Reply <Identifier %x>]\n", msg->identifier);
 
-	/*if (msg->identifier != conn->echo_sent) {
-		log_ppp_warn("pptp:echo: identifier mismatch\n");
-		//return -1;
-	}*/
 	conn->echo_sent = 0;
 	return 0;
 }
+
 static void pptp_send_echo(struct triton_timer_t *t)
 {
 	struct pptp_conn_t *conn = container_of(t, typeof(*conn), echo_timer);
@@ -443,8 +440,7 @@ static void pptp_send_echo(struct triton_timer_t *t)
 		return;
 	}
 
-	conn->echo_sent = random();
-	msg.identifier = conn->echo_sent;
+	msg.identifier = random();
 
 	if (conf_verbose)
 		log_ppp_debug("send [PPTP Echo-Request <Identifier %x>]\n", msg.identifier);
@@ -761,7 +757,7 @@ static void load_config(void)
 		conf_echo_interval = atoi(opt);
 
 	opt = conf_get_opt("pptp", "echo-failure");
-	if (opt && atoi(opt) > 0)
+	if (opt && atoi(opt) >= 0)
 		conf_echo_failure = atoi(opt);
 
 	opt = conf_get_opt("pptp", "verbose");

--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -413,6 +413,9 @@ static int pptp_echo_rqst(struct pptp_conn_t *conn)
 		log_ppp_debug("send [PPTP Echo-Reply <Identifier %x>]\n", out_msg.identifier);
 	}
 
+	if (conn->echo_timer.tpd)
+		triton_timer_mod(&conn->echo_timer, 0);
+
 	return post_msg(conn, &out_msg, sizeof(out_msg));
 }
 


### PR DESCRIPTION
With echo-falure properly set, pptp channel might be disconnected on any fail number (i.e on first fail, never), due failed echo counter contains random value, not actual fail count.
With incoming pptp echo request/l2tp hello there's no need to ask peer for replies in configured echo-interval, assuming the channel is working.  So just postpone next request.
It helps against false-positive echo failures with heavily loaded channels and/or peers.
