### PR TITLE
ppp: implement per-ctrl ppp interface rename support

### DIFF
--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -70,6 +70,7 @@ unit-cache=1
 [pptp]
 verbose=1
 #echo-interval=30
+#ifname=pptp%d
 
 [pppoe]
 verbose=1
@@ -81,6 +82,7 @@ called-sid=mac
 #tr101=1
 #padi-limit=0
 #ip-pool=pppoe
+#ifname=pppoe%d
 #sid-uppercase=0
 #vlan-mon=eth0,10-200
 #vlan-timeout=60
@@ -103,6 +105,7 @@ verbose=1
 #dataseq=allow
 #reorder-timeout=0
 #ip-pool=l2tp
+#ifname=l2tp%d
 
 [ipoe]
 verbose=1

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -462,6 +462,11 @@ Specifies maximum number of echo-requests may be sent without valid echo-reply, 
 Timeout waiting reply from client in seconds (default 5).
 .TP
 .BI "mppe=" deny|allow|prefer|require
+.TP
+.BI "ifname=" ifname
+If this option is given ppp interface will be renamed using
+.B ifname
+as a template, i.e pptp%d => pptp0.
 .SH [pppoe]
 .br
 Configuration of PPPoE module.
@@ -522,6 +527,11 @@ Specifies whether to handle TR101 tags.
 Specifies overall limit of PADI packets to reply in 1 second period (default 0 - unlimited). Rate of per-mac PADI packets is limited to no more than 1 packet per second.
 .TP
 .BI "mppe=" deny|allow|prefer|require
+.TP
+.BI "ifname=" ifname
+If this option is given ppp interface will be renamed using
+.B ifname
+as a template, i.e pppoe%d => pppoe0.
 .SH [l2tp]
 .br
 Configuration of L2TP module.
@@ -572,7 +582,6 @@ is greater of zero then l2tp module will produce verbose logging.
 .TP
 .BI "mppe=" deny|allow|prefer|require
 .TP
-.TP
 .BI "secret=" string
 Specifies secret to connect to server.
 .TP
@@ -609,6 +618,11 @@ reply (SCCRP). Default value is 0.
 .BI "ppp-max-mtu=" n
 Set the maximun MTU value that can be negociated for PPP over L2TP
 sessions. Default value is 1420.
+.TP
+.BI "ifname=" ifname
+If this option is given ppp interface will be renamed using
+.B ifname
+as a template, i.e l2tp%d => l2tp0.
 .SH [radius]
 .br
 Configuration of RADIUS module.

--- a/accel-pppd/ctrl/l2tp/l2tp.c
+++ b/accel-pppd/ctrl/l2tp/l2tp.c
@@ -94,6 +94,7 @@ static int conf_mppe = MPPE_UNSET;
 static int conf_dataseq = L2TP_DATASEQ_ALLOW;
 static int conf_reorder_timeout = 0;
 static const char *conf_ip_pool;
+static const char *conf_ifname;
 
 static unsigned int stat_conn_starting;
 static unsigned int stat_conn_active;
@@ -1796,6 +1797,8 @@ static int l2tp_session_start_data_channel(struct l2tp_sess_t *sess)
 			goto err;
 		}
 	}
+	if (conf_ifname)
+		sess->ppp.ses.ifname_rename = _strdup(conf_ifname);
 
 	sess->ppp.ses.ctrl = &sess->ctrl;
 	sess->apses_state = APSTATE_INIT;
@@ -4928,6 +4931,7 @@ static void load_config(void)
 	}
 
 	conf_ip_pool = conf_get_opt("l2tp", "ip-pool");
+	conf_ifname = conf_get_opt("l2tp", "ifname");
 
 	switch (iprange_check_activation()) {
 	case IPRANGE_DISABLED:

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -98,6 +98,7 @@ int conf_padi_limit = 0;
 int conf_mppe = MPPE_UNSET;
 int conf_sid_uppercase = 0;
 static const char *conf_ip_pool;
+static const char *conf_ifname;
 enum {CSID_MAC, CSID_IFNAME, CSID_IFNAME_MAC};
 static int conf_called_sid;
 static int conf_cookie_timeout;
@@ -407,6 +408,8 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 
 	if (conf_ip_pool)
 		conn->ppp.ses.ipv4_pool_name = _strdup(conf_ip_pool);
+	if (conf_ifname)
+		conn->ppp.ses.ifname_rename = _strdup(conf_ifname);
 
 	triton_context_register(&conn->ctx, conn);
 
@@ -2009,6 +2012,7 @@ static void load_config(void)
 	}
 
 	conf_ip_pool = conf_get_opt("pppoe", "ip-pool");
+	conf_ifname = conf_get_opt("pppoe", "ifname");
 
 	conf_called_sid = CSID_MAC;
 	opt = conf_get_opt("pppoe", "called-sid");

--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -61,6 +61,7 @@ static int conf_echo_failure = 3;
 static int conf_verbose = 0;
 static int conf_mppe = MPPE_UNSET;
 static const char *conf_ip_pool;
+static const char *conf_ifname;
 
 static mempool_t conn_pool;
 
@@ -705,6 +706,8 @@ static int pptp_connect(struct triton_md_handler_t *h)
 
 		if (conf_ip_pool)
 			conn->ppp.ses.ipv4_pool_name = _strdup(conf_ip_pool);
+		if (conf_ifname)
+			conn->ppp.ses.ifname_rename = _strdup(conf_ifname);
 
 		triton_context_register(&conn->ctx, &conn->ppp.ses);
 		triton_md_register_handler(&conn->ctx, &conn->hnd);
@@ -781,6 +784,7 @@ static void load_config(void)
 	}
 
 	conf_ip_pool = conf_get_opt("pptp", "ip-pool");
+	conf_ifname = conf_get_opt("pptp", "ifname");
 
 	switch (iprange_check_activation()) {
 	case IPRANGE_DISABLED:


### PR DESCRIPTION
Reuse exsisting radius functionality and allow set iterface name template for pppoe/pptp/l2tp, '%d' specification will be replaced automagically to the next available index by kernel.
PPP interface rename allows to easy differ client's interfaces from the other ppp ones, for example, with just netfilter interface rules.

Example:
  [pptp]
  ifname=pptp%d will produce pptp0, pptp1, ...