### PR TITLE
chap-secrets: add pool name support

### DIFF
--- a/accel-pppd/extra/chap-secrets.c
+++ b/accel-pppd/extra/chap-secrets.c
@@ -123,14 +123,16 @@ static struct cs_pd_t *create_pd(struct ap_session *ses, const char *username)
 	FILE *f;
 	char *buf;
 	char *ptr[5];
-	int n, i;
+	int n;
 	struct cs_pd_t *pd;
+	struct in_addr in;
 #ifdef CRYPTO_OPENSSL
 	char username_hash[EVP_MAX_MD_SIZE * 2 + 1];
 	uint8_t hash[EVP_MAX_MD_SIZE];
 	struct hash_chain *hc;
 	EVP_MD_CTX *md_ctx = NULL;
 	char c;
+	int i;
 #endif
 
 	if (!conf_chap_secrets)
@@ -230,11 +232,11 @@ found:
 	}
 
 	pd->ip.addr = conf_gw_ip_address;
-	if (n >= 3 && ptr[2][0] != '*') {
-		if (strncmp(ptr[2], "pool=", 5) == 0)
-			pd->pool = _strdup(ptr[2] + 5);
+	if (n >= 3 && !strchr("*-!", ptr[2][0])) {
+		if (inet_aton(ptr[2], &in))
+			pd->ip.peer_addr = in.s_addr;
 		else
-			pd->ip.peer_addr = inet_addr(ptr[2]);
+			pd->pool = _strdup(ptr[2]);
 	}
 	pd->ip.mask = conf_netmask;
 	pd->ip.owner = &ipdb;


### PR DESCRIPTION
Chap-secrets' ipdb uses 4th field as static peer ipv4 address. With no radius and multiple same username sessions, it's impossible to use non-default pool for such sessions.
Abuse chap-secret's 4th field as pool=name to specify session's pool name.
With ippool module loaded after chap-secrets (default order), it will be used for allocation from the specified poll name.

Compatibility considerations:
* pppd will skip 'pool=*' with warn 'unknown host in auth. address list' same as 5th field - shaper, because starting from 4th field pppd parse list of value. so, no new effects here.
* previous versions of accel-ppp will parse 'pool=*' as invalid 255.255.255.255 address.
* with no 'pool=*' in chap-secrets or with no chap-secrets loaded, no behavior change.
* with no ippool loaded, session will get no peer address.
* with ippool loaded before chap-secrets, chap-secrets's ipdb will not be used, therefore neither ip addess not pool name will has no effect.
* if chap-secrets' pool is invalid or not found, default pool will be used by ippool or address came from radius.
* chap-secret's pool name might override pool came from radius, if radius module is loaded after chap-secrets and no address came from radius.