### PR TITLE
Ipv6 pool fixes

### DIFF
--- a/accel-pppd/extra/pppd_compat.c
+++ b/accel-pppd/extra/pppd_compat.c
@@ -578,16 +578,6 @@ static void fill_argv(char **argv, struct pppd_compat_pd *pd, char *path)
 	argv[7] = NULL;
 }
 
-static void build_addr(struct ipv6db_addr_t *a, uint64_t intf_id, struct in6_addr *addr)
-{
-	memcpy(addr, &a->addr, sizeof(*addr));
-
-	if (a->prefix_len <= 64)
-		*(uint64_t *)(addr->s6_addr + 8) = intf_id;
-	else
-		*(uint64_t *)(addr->s6_addr + 8) |= intf_id & htobe64((1 << (128 - a->prefix_len)) - 1);
-}
-
 static void fill_env(char **env, char *mem, struct pppd_compat_pd *pd)
 {
 	struct ap_session *ses = pd->ses;
@@ -628,7 +618,7 @@ static void fill_env(char **env, char *mem, struct pppd_compat_pd *pd)
 		char ip6_buf[INET6_ADDRSTRLEN];
 		struct in6_addr addr;
 
-		build_addr(a, ses->ipv6->peer_intf_id, &addr);
+		build_ip6_addr(a, ses->ipv6->peer_intf_id, &addr);
 
 		env[n] = mem;
 		write_sz = snprintf(mem, mem_sz, "IPV6_PREFIX=%s/%i",

--- a/accel-pppd/ifcfg.c
+++ b/accel-pppd/ifcfg.c
@@ -149,7 +149,7 @@ void __export ap_session_accounting_started(struct ap_session *ses)
 
 				if (ses->ctrl->ppp) {
 					ifr6.ifr6_addr.s6_addr32[0] = htonl(0xfe800000);
-					*(uint64_t *)(ifr6.ifr6_addr.s6_addr + 8) = ses->ipv6->intf_id;
+					memcpy(ifr6.ifr6_addr.s6_addr + 8, &ses->ipv6->intf_id, 8);
 					ifr6.ifr6_prefixlen = 64;
 					ifr6.ifr6_ifindex = ses->ifindex;
 

--- a/accel-pppd/ifcfg.c
+++ b/accel-pppd/ifcfg.c
@@ -45,16 +45,6 @@ static void devconf(struct ap_session *ses, const char *attr, const char *val)
 	close(fd);
 }
 
-/*static void build_addr(struct ipv6db_addr_t *a, uint64_t intf_id, struct in6_addr *addr)
-{
-	memcpy(addr, &a->addr, sizeof(*addr));
-
-	if (a->prefix_len <= 64)
-		*(uint64_t *)(addr->s6_addr + 8) = intf_id;
-	else
-		*(uint64_t *)(addr->s6_addr + 8) |= intf_id & htobe64((1 << (128 - a->prefix_len)) - 1);
-}*/
-
 void ap_session_ifup(struct ap_session *ses)
 {
 	if (ses->ifname_rename) {
@@ -170,7 +160,7 @@ void __export ap_session_accounting_started(struct ap_session *ses)
 				list_for_each_entry(a, &ses->ipv6->addr_list, entry) {
 					a->installed = 0;
 					/*if (a->prefix_len < 128) {
-						build_addr(a, ses->ipv6->intf_id, &ifr6.ifr6_addr);
+						build_ip6_addr(a, ses->ipv6->intf_id, &ifr6.ifr6_addr);
 						ifr6.ifr6_prefixlen = a->prefix_len;
 
 						if (ioctl(sock6_fd, SIOCSIFADDR, &ifr6))

--- a/accel-pppd/ipdb.c
+++ b/accel-pppd/ipdb.c
@@ -77,10 +77,14 @@ void __export build_ip6_addr(struct ipv6db_addr_t *a, uint64_t intf_id, struct i
 {
 	memcpy(addr, &a->addr, sizeof(*addr));
 
+	if (a->prefix_len == 128)
+		return;
+
 	if (a->prefix_len <= 64)
 		*(uint64_t *)(addr->s6_addr + 8) = intf_id;
 	else
-		*(uint64_t *)(addr->s6_addr + 8) |= intf_id & ((1 << (128 - a->prefix_len)) - 1);
+		*(uint64_t *)(addr->s6_addr + 8) |= intf_id & htobe64((1 << (128 - a->prefix_len)) - 1);
+
 }
 
 void __export ipdb_register(struct ipdb_t *ipdb)

--- a/accel-pppd/ipv6/dhcpv6.c
+++ b/accel-pppd/ipv6/dhcpv6.c
@@ -52,7 +52,6 @@ struct dhcpv6_pd {
 };
 
 static void *pd_key;
-static struct in6_addr null_addr;
 
 static int dhcpv6_read(struct triton_md_handler_t *h);
 
@@ -69,7 +68,7 @@ static void ev_ses_started(struct ap_session *ses)
 		return;
 
 	a = list_entry(ses->ipv6->addr_list.next, typeof(*a), entry);
-	if (a->prefix_len == 0 || memcmp(a->addr.s6_addr, null_addr.s6_addr, sizeof(null_addr)) == 0)
+	if (a->prefix_len == 0 || IN6_IS_ADDR_UNSPECIFIED(&a->addr))
 		return;
 
 	sock = net->socket(AF_INET6, SOCK_DGRAM, 0);

--- a/accel-pppd/ipv6/dhcpv6_packet.c
+++ b/accel-pppd/ipv6/dhcpv6_packet.c
@@ -329,14 +329,14 @@ static void print_ia_na(struct dhcpv6_option *opt, void (*print)(const char *fmt
 {
 	struct dhcpv6_opt_ia_na *o = (struct dhcpv6_opt_ia_na *)opt->hdr;
 
-	print(" %x T1=%i T2=%i", o->iaid, ntohl(o->T1), ntohl(o->T2));
+	print(" %x T1=%i T2=%i", ntohl(o->iaid), ntohl(o->T1), ntohl(o->T2));
 }
 
 static void print_ia_ta(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...))
 {
 	struct dhcpv6_opt_ia_ta *o = (struct dhcpv6_opt_ia_ta *)opt->hdr;
 
-	print(" %x", o->iaid);
+	print(" %x", ntohl(o->iaid));
 }
 
 static void print_ia_addr(struct dhcpv6_option *opt, void (*print)(const char *fmt, ...))

--- a/accel-pppd/ipv6/nd.c
+++ b/accel-pppd/ipv6/nd.c
@@ -153,8 +153,10 @@ static void ipv6_nd_send_ra(struct ipv6_nd_handler_t *h, struct sockaddr_in6 *ds
 				memcpy(peer_addr.s6_addr + 8, &ses->ipv6->peer_intf_id, 8);
 				ip6addr_add_peer(ses->ifindex, &addr, &peer_addr);
 			} else {
-				memcpy(addr.s6_addr, &a->addr, 8);
-				memcpy(addr.s6_addr + 8, &ses->ipv6->intf_id, 8);
+				build_ip6_addr(a, ses->ipv6->intf_id, &addr);
+				build_ip6_addr(a, ses->ipv6->peer_intf_id, &peer_addr);
+				if (memcmp(&addr, &peer_addr, sizeof(addr)) == 0)
+					build_ip6_addr(a, ~ses->ipv6->intf_id, &addr);
 				ip6addr_add(ses->ifindex, &addr, a->prefix_len);
 			}
 			a->installed = 1;

--- a/accel-pppd/ipv6/nd.c
+++ b/accel-pppd/ipv6/nd.c
@@ -90,7 +90,6 @@ struct ipv6_nd_handler_t
 };
 
 static void *pd_key;
-static struct in6_addr null_addr;
 
 #define BUF_SIZE 1024
 static mempool_t buf_pool;
@@ -383,7 +382,7 @@ static void ev_ses_started(struct ap_session *ses)
 		return;
 
 	list_for_each_entry(a, &ses->ipv6->addr_list, entry) {
-		if (a->prefix_len && memcmp(a->addr.s6_addr, null_addr.s6_addr, sizeof(null_addr))) {
+		if (a->prefix_len && !IN6_IS_ADDR_UNSPECIFIED(&a->addr)) {
 			ipv6_nd_start(ses);
 			break;
 		}

--- a/accel-pppd/libnetlink/iputils.c
+++ b/accel-pppd/libnetlink/iputils.c
@@ -556,7 +556,7 @@ int __export ip6route_add(int ifindex, struct in6_addr *dst, int pref_len, int p
 	req.n.nlmsg_type = RTM_NEWROUTE;
 	req.i.rtm_family = AF_INET6;
 	req.i.rtm_table = RT_TABLE_MAIN;
-	req.i.rtm_scope = RT_SCOPE_LINK;
+	req.i.rtm_scope = (pref_len == 128) ? RT_SCOPE_HOST : RT_SCOPE_LINK;
 	req.i.rtm_protocol = proto;
 	req.i.rtm_type = RTN_UNICAST;
 	req.i.rtm_dst_len = pref_len;
@@ -592,7 +592,7 @@ int __export ip6route_del(int ifindex, struct in6_addr *dst, int pref_len)
 	req.n.nlmsg_type = RTM_DELROUTE;
 	req.i.rtm_family = AF_INET6;
 	req.i.rtm_table = RT_TABLE_MAIN;
-	req.i.rtm_scope = RT_SCOPE_LINK;
+	req.i.rtm_scope = (pref_len == 128) ? RT_SCOPE_HOST : RT_SCOPE_LINK;
 	req.i.rtm_type = RTN_UNICAST;
 	req.i.rtm_dst_len = pref_len;
 


### PR DESCRIPTION
Prefix range from /65 to /127 handling is consolidated to be consistent in all places.
Conflict between equal local and peer addrs is solved by inversing local interface id.
The last one patch changes PD routes' nexthop from all the peer's addresses to one peer's linklocal address.