### PR TITLE
accel-cmd: add -P/--password support

### DIFF
--- a/accel-cmd/accel-cmd.1
+++ b/accel-cmd/accel-cmd.1
@@ -46,6 +46,11 @@ Set the service name or port number on which connection should be done.
 .RI "If this option is not supplied, or if " TIMEOUT " is zero, then no"
 timeout is set.
 .TP
+.BR \-P " \fIPASSWORD\fR, " \-\-password "=\fIPASSWORD\fR"
+.RB "Set the password."
+.RB "If this option is supplied and if " PASSWORD " is not empty, then"
+.RB "password will be used for client authentication."
+.TP
 .BR \-v ", " \-\-verbose
 Verbose output.
 .TP


### PR DESCRIPTION
Useful for accel-cmd oneliners when cli password is set.
Existing behavior is not affected, incl. echo "...multiline..." | accel-cmd with password on 1st line