### PR TITLE
fix gateway address setup fail due memory corruption

### DIFF
--- a/accel-pppd/extra/chap-secrets.c
+++ b/accel-pppd/extra/chap-secrets.c
@@ -24,7 +24,7 @@ static char *def_chap_secrets = "/etc/ppp/chap-secrets";
 static char *conf_chap_secrets;
 static int conf_encrypted;
 static in_addr_t conf_gw_ip_address = 0;
-static int conf_netmask;
+static int conf_netmask = 0;
 
 static void *pd_key;
 static struct ipdb_t ipdb;
@@ -762,6 +762,7 @@ static void load_config(void)
 		parse_gw_ip_address(opt);
 	else {
 		conf_gw_ip_address = 0;
+		conf_netmask = 0;
 	}
 
 	opt = conf_get_opt("chap-secrets", "encrypted");

--- a/accel-pppd/extra/ippool.c
+++ b/accel-pppd/extra/ippool.c
@@ -264,6 +264,7 @@ static void generate_pool_p2p(struct ippool_t *p)
 			break;
 		}
 
+		memset(it, 0, sizeof(*it));
 		it->pool = p;
 		it->it.owner = &ipdb;
 		if (conf_gw_ip_address)
@@ -304,6 +305,7 @@ static void generate_pool_net30(struct ippool_t *p)
 			break;
 		}
 
+		memset(it, 0, sizeof(*it));
 		it->pool = p;
 		it->it.owner = &ipdb;
 		it->it.addr = addr[1]->addr;
@@ -443,6 +445,7 @@ static int session_restore(struct ap_session *ses, struct backup_mod *m)
 		ses->ipv4 = &it0->it;
 	else {
 		ses->ipv4 = _malloc(sizeof(*ses->ipv4));
+		memset(ses->ipv4, 0, sizeof(*ses->ipv4));
 		ses->ipv4->addr = addr;
 		ses->ipv4->peer_addr = peer_addr;
 		ses->ipv4->owner = &ipdb_b;

--- a/accel-pppd/extra/ipv6pool.c
+++ b/accel-pppd/extra/ipv6pool.c
@@ -83,6 +83,7 @@ static void generate_ippool(struct in6_addr *addr, int mask, int prefix_len)
 
 	while (in6_addr_cmp(&ip, &end) <= 0) {
 		it = malloc(sizeof(*it));
+		memset(it, 0, sizeof(*it));
 		it->it.owner = &ipdb;
 		INIT_LIST_HEAD(&it->it.addr_list);
 		a = malloc(sizeof(*a));
@@ -119,6 +120,7 @@ static void generate_dppool(struct in6_addr *addr, int mask, int prefix_len)
 
 	while (in6_addr_cmp(&ip, &end) <= 0) {
 		it = malloc(sizeof(*it));
+		memset(it, 0, sizeof(*it));
 		it->it.owner = &ipdb;
 		INIT_LIST_HEAD(&it->it.prefix_list);
 		a = malloc(sizeof(*a));


### PR DESCRIPTION
log:
 libnetlink: RTNETLINK answers: Invalid argument
 ppp0: f7bb00a79ef667d2: failed to set IPv4 address: Invalid argument

ipaddr_add_peer() called only with mask equeal 0 or 32, but w/o
zero-allocated structs it contans garbage in some cases.
so, instead ipaddr_add() was called with wrong mask value.
also, init chap-secrets mask for the same reason.