### PR TITLE
Fix work on fresh kernels

### DIFF
--- a/accel-pppd/ctrl/ipoe/arp.c
+++ b/accel-pppd/ctrl/ipoe/arp.c
@@ -59,6 +59,7 @@ static void arp_ctx_read(struct _arphdr *ah)
 	memset(&dst, 0, sizeof(dst));
 	dst.sll_family = AF_PACKET;
 	dst.sll_ifindex = ipoe->ifindex;
+	dst.sll_halen = ETH_ALEN;
 	dst.sll_protocol = htons(ETH_P_ARP);
 
 	ah2.ar_hrd = htons(ARPHRD_ETHER);
@@ -136,6 +137,7 @@ void arp_send(int ifindex, struct _arphdr *arph, int broadcast)
 	memset(&dst, 0, sizeof(dst));
 	dst.sll_family = AF_PACKET;
 	dst.sll_ifindex = ifindex;
+	dst.sll_halen = ETH_ALEN;
 	dst.sll_protocol = htons(ETH_P_ARP);
 	if (broadcast)
 		memcpy(dst.sll_addr, bc_addr, ETH_ALEN);

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -748,6 +748,7 @@ static void pppoe_send(struct pppoe_serv_t *serv, const uint8_t *pack)
 		.sll_family = AF_PACKET,
 		.sll_protocol = htons(ETH_P_PPP_DISC),
 		.sll_ifindex = serv->ifindex,
+		.sll_halen = ETH_ALEN,
 	};
 
 	struct pppoe_hdr *hdr = (struct pppoe_hdr *)(pack + ETH_HLEN);


### PR DESCRIPTION
Fixes sending of the arp replies with fresh kernels
3.18.132, 4.4.170, 4.9.149, 4.14.92, 4.19.14, 4.20