### PR TITLE
Added extra AVP to SCCCN as known to allow MPD5 tunnels

### DIFF
--- a/accel-pppd/ctrl/l2tp/l2tp.c
+++ b/accel-pppd/ctrl/l2tp/l2tp.c
@@ -3053,6 +3053,13 @@ static int l2tp_recv_SCCCN(struct l2tp_conn_t *conn,
 	list_for_each_entry(attr, &pack->attrs, entry) {
 		switch (attr->attr->id) {
 		case Message_Type:
+		case Host_Name:
+		case Vendor_Name:
+		case Bearer_Capabilities:
+		case Recv_Window_Size:
+		case Protocol_Version:
+		case Framing_Capabilities:
+		case Assigned_Tunnel_ID:
 		case Random_Vector:
 			break;
 		case Challenge_Response:


### PR DESCRIPTION
@dyangol investigated that this were the field MPD5 tunnels required to make accel-ppp work for [bsdrp](https://bsdrp.net/) routers

I don't know if there is a better way to handle that