### PR TITLE
Added support for Debian10 DEB pack generation

### DIFF
--- a/cmake/cpack.cmake
+++ b/cmake/cpack.cmake
@@ -37,14 +37,19 @@ IF(CPACK_TYPE STREQUAL Debian9)
 	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
 ENDIF(CPACK_TYPE STREQUAL Debian9)
 
+IF(CPACK_TYPE STREQUAL Debian10)
+	SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.28), libssl1.1 (>= 1.1.1c), libpcre3 (>= 8.39)")
+	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
+ENDIF(CPACK_TYPE STREQUAL Debian10)
+
 IF(CPACK_TYPE STREQUAL Ubuntu16)
-        SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.24), libssl1.0.0 (>= 1.0.2t), libpcre3 (>= 8.39)")
-        INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
+	SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.24), libssl1.0.0 (>= 1.0.2t), libpcre3 (>= 8.39)")
+	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
 ENDIF(CPACK_TYPE STREQUAL Ubuntu16)
 
 IF(CPACK_TYPE STREQUAL Ubuntu18)
-        SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.24), libssl1.0.0 (>= 1.0.2n), libpcre3 (>= 8.39)")
-        INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
+	SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.24), libssl1.0.0 (>= 1.0.2n), libpcre3 (>= 8.39)")
+	INCLUDE(${CMAKE_HOME_DIRECTORY}/cmake/debian/debian.cmake)
 ENDIF(CPACK_TYPE STREQUAL Ubuntu18)
 
 IF(CPACK_TYPE STREQUAL Centos7)


### PR DESCRIPTION
On Debian 10 (Buster) it is impossible to install Accel-PPP due to required different OpenSSL version in deb file, while compilation passing smoothly and binaries are operational.

Added CPack Debian10 option