### PR TITLE
sstp: implement ssl-protocol option and add unsupported features logging

### DIFF
--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -112,6 +112,7 @@ verbose=1
 #cert-hash-sha1=
 #cert-hash-sha256=
 #accept=ssl,proxy
+#ssl-protocol=tls1,tls1.1,tls1.2,tls1.3
 #ssl-dhparam=/etc/ssl/dhparam.pem
 #ssl-ecdh-curve=prime256v1
 #ssl-ciphers=DEFAULT

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -715,6 +715,9 @@ Specifies incoming connection acceptance mode.
 .B proxy
 - enable PROXY protocol 1 & 2 support.
 .TP
+.BI "ssl-protocol=" ssl2|ssl3|tls1|tls1.1|tls1.2|tls1.3
+Specifies the enabled SSL/TLS protocols supported by OpenSSL library.
+.TP
 .BI "ssl-dhparam=" pemfile
 Specifies a file with DH parameters for DHE ciphers.
 .TP

--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -2387,7 +2387,7 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 			goto error;
 		}
 
-		SSL_CTX_set_options(ssl_ctx,
+		SSL_CTX_set_options(ssl_ctx, SSL_OP_ALL |
 #ifdef SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
 				SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS |
 #endif

--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -2362,18 +2362,18 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 	if (opt) {
 		in = BIO_new(BIO_s_file());
 		if (!in) {
-			log_error("sstp: SSL certificate error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_error("sstp: %s error: %s\n", "ssl-pemfile", ERR_error_string(ERR_get_error(), NULL));
 			goto error;
 		}
 
 		if (BIO_read_filename(in, opt) <= 0) {
-			log_error("sstp: SSL certificate error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_error("sstp: %s error: %s\n", "ssl-pemfile", ERR_error_string(ERR_get_error(), NULL));
 			goto error;
 		}
 
 		cert = PEM_read_bio_X509(in, NULL, NULL, NULL);
 		if (!cert) {
-			log_error("sstp: SSL certificate error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_error("sstp: %s error: %s\n", "ssl-pemfile", ERR_error_string(ERR_get_error(), NULL));
 			goto error;
 		}
 	}
@@ -2383,7 +2383,7 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 	legacy_ssl:
 		ssl_ctx = SSL_CTX_new(SSLv23_server_method());
 		if (!ssl_ctx) {
-			log_error("sstp: SSL_CTX error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_error("sstp: %s error: %s\n", "SSL_CTX_new", ERR_error_string(ERR_get_error(), NULL));
 			goto error;
 		}
 
@@ -2472,13 +2472,13 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 			DH *dh;
 
 			if (BIO_read_filename(in, opt) <= 0) {
-				log_error("sstp: SSL dhparam error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+				log_error("sstp: %s error: %s\n", "ssl-dhparam", ERR_error_string(ERR_get_error(), NULL));
 				goto error;
 			}
 
 			dh = PEM_read_bio_DHparams(in, NULL, NULL, NULL);
 			if (dh == NULL) {
-				log_error("sstp: SSL dhparam error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+				log_error("sstp: %s error: %s\n", "ssl-dhparam", ERR_error_string(ERR_get_error(), NULL));
 				goto error;
 			}
 
@@ -2499,7 +2499,7 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 			SSL_CTX_set_ecdh_auto(ssl_ctx, 1);
 #endif
 			if (opt && SSL_CTX_set1_curves_list(ssl_ctx, opt) == 0) {
-				log_error("sstp: SSL ecdh-curve error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+				log_error("sstp: %s error: %s\n", "ssl-ecdh-curve", ERR_error_string(ERR_get_error(), NULL));
 				goto error;
 			}
 #else
@@ -2508,13 +2508,13 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 
 			nid = OBJ_sn2nid(opt ? : "prime256v1");
 			if (nid == 0) {
-				log_error("sstp: SSL ecdh-curve error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+				log_error("sstp: %s error: %s\n", "ssl-ecdh-curve", ERR_error_string(ERR_get_error(), NULL));
 				goto error;
 			}
 
 			ecdh = EC_KEY_new_by_curve_name(nid);
 			if (ecdh == NULL) {
-				log_error("sstp: SSL ecdh-curve error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+				log_error("sstp: %s error: %s\n", "ssl-ecdh-curve", ERR_error_string(ERR_get_error(), NULL));
 				goto error;
 			}
 
@@ -2526,7 +2526,7 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 
 		opt = conf_get_opt("sstp", "ssl-ciphers");
 		if (opt && SSL_CTX_set_cipher_list(ssl_ctx, opt) != 1) {
-			log_error("sstp: SSL cipher list error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_error("sstp: %s error: %s\n", "ssl-ciphers", ERR_error_string(ERR_get_error(), NULL));
 			goto error;
 		}
 
@@ -2535,26 +2535,26 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 			SSL_CTX_set_options(ssl_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
 
 		if (cert && SSL_CTX_use_certificate(ssl_ctx, cert) != 1) {
-			log_error("sstp: SSL certificate error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_error("sstp: %s error: %s\n", "ssl-pemfile", ERR_error_string(ERR_get_error(), NULL));
 			goto error;
 		}
 
 		opt = conf_get_opt("sstp", "ssl-keyfile") ? : conf_get_opt("sstp", "ssl-pemfile");
 		if ((opt && SSL_CTX_use_PrivateKey_file(ssl_ctx, opt, SSL_FILETYPE_PEM) != 1) ||
 		    SSL_CTX_check_private_key(ssl_ctx) != 1) {
-			log_error("sstp: SSL private key error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_error("sstp: %s error: %s\n", "ssl-keyfile", ERR_error_string(ERR_get_error(), NULL));
 			goto error;
 		}
 
 		opt = conf_get_opt("sstp", "ssl-ca-file");
 		if (opt && SSL_CTX_load_verify_locations(ssl_ctx, opt, NULL) != 1) {
-			log_error("sstp: SSL ca file error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_error("sstp: %s error: %s\n", "ssl-ca-file", ERR_error_string(ERR_get_error(), NULL));
 			goto error;
 		}
 
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 		if (servername && SSL_CTX_set_tlsext_servername_callback(ssl_ctx, ssl_servername) != 1)
-			log_warn("sstp: SSL server name check error: %s\n", ERR_error_string(ERR_get_error(), NULL));
+			log_warn("sstp: %s error: %s\n", "host-name", ERR_error_string(ERR_get_error(), NULL));
 #endif
 
 #ifndef SSL_OP_NO_RENEGOTIATION

--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -2464,9 +2464,11 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 #endif
 		}
 
-#ifndef OPENSSL_NO_DH
 		opt = conf_get_opt("sstp", "ssl-dhparam");
 		if (opt) {
+#ifdef OPENSSL_NO_DH
+			log_warn("sstp: %s warning: %s is not suported\n", "ssl-protocol", "DH");
+#else
 			DH *dh;
 
 			if (BIO_read_filename(in, opt) <= 0) {
@@ -2482,11 +2484,14 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 
 			SSL_CTX_set_tmp_dh(ssl_ctx, dh);
 			DH_free(dh);
-		}
 #endif
+		}
 
-#ifndef OPENSSL_NO_ECDH
 		opt = conf_get_opt("sstp", "ssl-ecdh-curve");
+#ifdef OPENSSL_NO_ECDH
+		if (opt)
+			log_warn("sstp: %s warning: %s is not suported\n", "ssl-protocol", "ECDH");
+#else
 		{
 #if defined(SSL_CTX_set1_curves_list) || defined(SSL_CTRL_SET_CURVES_LIST)
 #ifdef SSL_CTRL_SET_ECDH_AUTO


### PR DESCRIPTION
openssl 1.1.1 has no SSLv2/SSLv3 support and defaults to TLSv1.2 as minimum, what breaks old SSTP client connections via TLSv1.
now it's possible to set ssl-protocol to tls1,tls1.1,tls1.2,tls1.3 if needed.
in case of some protocols/DH/ECDH not supported by openssl library, corresponding warnings will be logged.