### PR TITLE
[Fix] - Increment Accounting-Request id for Acct-Status-Type Stop

### DIFF
--- a/accel-pppd/radius/acct.c
+++ b/accel-pppd/radius/acct.c
@@ -487,6 +487,8 @@ int rad_acct_stop(struct radius_pd_t *rpd)
 			break;
 	}
 
+	req->pack->id++;
+
 	rad_packet_change_val(req->pack, NULL, "Acct-Status-Type", "Stop");
 	req_set_stat(req, rpd->ses);
 	req_set_RA(req, req->serv->secret);


### PR DESCRIPTION
Accounting stop is sent with the same id as the last Interium-update id. 
In some cases, when interium-update and stop packets are sent almost simultaneously 
(e.g. when acct-interim-interval and lease-time are equal),
RADIUS could generate error:
_Discarding conflicting packet from client due to recent request for second packet._

