### PR TITLE
ppp/ipoe: cleanup cleck-ip support

### DIFF
--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -124,7 +124,7 @@ Path to file for sessions sequence number. Start sequence number may be set ther
 Specifies maximum sessions which server may processed (default 0, disabled)
 .TP
 .BI "check-ip=" 0|1
-Specifies whether accel-ppp should check if IP already assigned to other ppp interface (default 0).
+Specifies whether accel-ppp should check if IP already assigned to other client interface (default 0).
 .SH [ppp]
 .br
 PPP module configuration.

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -3954,8 +3954,10 @@ static void load_config(void)
 	else
 		conf_weight = 0;
 
-	opt = conf_get_opt("common", "check-ip");
-	if (opt && atoi(opt) >= 0)
+	opt = conf_get_opt("ipoe", "check-ip");
+	if (!opt)
+		opt = conf_get_opt("common", "check-ip");
+	if (opt && opt >= 0)
 		conf_check_exists = atoi(opt) > 0;
 
 #ifdef RADIUS

--- a/accel-pppd/ppp/ipcp_opt_ipaddr.c
+++ b/accel-pppd/ppp/ipcp_opt_ipaddr.c
@@ -171,14 +171,11 @@ static void load_config(void)
 {
 	const char *opt;
 
-	opt = conf_get_opt("common", "check-ip");
-	if (opt && atoi(opt) > 0)
-		conf_check_exists = atoi(opt);
-	else {
-		opt = conf_get_opt("ppp", "check-ip");
-		if (opt && atoi(opt) >= 0)
-			conf_check_exists = atoi(opt) > 0;
-	}
+	opt = conf_get_opt("ppp", "check-ip");
+	if (!opt)
+		opt = conf_get_opt("common", "check-ip");
+	if (opt && atoi(opt) >= 0)
+		conf_check_exists = atoi(opt) > 0;
 }
 
 static void ipaddr_opt_init()

--- a/accel-pppd/ppp/ipv6cp_opt_intfid.c
+++ b/accel-pppd/ppp/ipv6cp_opt_intfid.c
@@ -317,6 +317,8 @@ static void load_config(void)
 	const char *opt;
 
 	opt = conf_get_opt("ppp", "check-ip");
+	if (!opt)
+		opt = conf_get_opt("common", "check-ip");
 	if (opt && atoi(opt) >= 0)
 		conf_check_exists = atoi(opt) > 0;
 


### PR DESCRIPTION
let check-ip setting from [ppp]/[ipoe] sections has prio over [common]
for compatibility with older configs.