### PR TITLE
radius: add support for Access-Accept username

### DIFF
--- a/accel-pppd/radius/backup.c
+++ b/accel-pppd/radius/backup.c
@@ -22,6 +22,7 @@
 #define RAD_TAG_ACCT_SERVER_ADDR            9
 #define RAD_TAG_ACCT_SERVER_PORT           10
 #define RAD_TAG_IDLE_TIMEOUT               11
+#define RAD_TAG_ACCT_USERNAME              12
 
 
 #define add_tag(id, data, size) if (!backup_add_tag(m, id, 0, data, size)) return -1;
@@ -67,6 +68,9 @@ static int session_save(struct ap_session *ses, struct backup_mod *m)
 		add_tag(RAD_TAG_ATTR_CLASS, rpd->attr_state, rpd->attr_state_len);
 
 	add_tag(RAD_TAG_TERMINATION_ACTION, &rpd->termination_action, 4);
+
+	if (rpd->acct_username)
+		add_tag(RAD_TAG_ACCT_USERNAME, rpd->acct_username, strlen(rpd->acct_username));
 
 	if (rpd->acct_req) {
 		add_tag(RAD_TAG_ACCT_SERVER_ADDR, &rpd->acct_req->server_addr, 4);
@@ -143,6 +147,9 @@ void radius_restore_session(struct ap_session *ses, struct radius_pd_t *rpd)
 				break;
 			case RAD_TAG_TERMINATION_ACTION:
 				rpd->termination_action = *(uint32_t *)tag->data;
+				break;
+			case RAD_TAG_ACCT_USERNAME:
+				rpd->acct_username = _strndup(tag->data, tag->size);
 				break;
 			case RAD_TAG_ACCT_SERVER_ADDR:
 				acct_addr = *(in_addr_t *)tag->data;

--- a/accel-pppd/radius/dm_coa.c
+++ b/accel-pppd/radius/dm_coa.c
@@ -217,19 +217,19 @@ static int dm_coa_read(struct triton_md_handler_t *h)
 		if (!pack)
 			continue;
 
-		if (pack->code != CODE_DISCONNECT_REQUEST	&& pack->code != CODE_COA_REQUEST) {
+		if (pack->code != CODE_DISCONNECT_REQUEST && pack->code != CODE_COA_REQUEST) {
 			log_warn("radius:dm_coa: unexpected code (%i) received\n", pack->code);
-			goto out_err_no_reply;
-		}
-
-		if (dm_coa_check_RA(pack, conf_dm_coa_secret)) {
-			log_warn("radius:dm_coa: RA validation failed\n");
 			goto out_err_no_reply;
 		}
 
 		if (conf_verbose) {
 			log_debug("recv ");
 			rad_packet_print(pack, NULL, log_debug);
+		}
+
+		if (dm_coa_check_RA(pack, conf_dm_coa_secret)) {
+			log_warn("radius:dm_coa: RA validation failed\n");
+			goto out_err_no_reply;
 		}
 
 		if (rad_check_nas_pack(pack)) {
@@ -293,29 +293,29 @@ static void init(void)
 	}
 
 	serv.hnd.fd = socket (PF_INET, SOCK_DGRAM, 0);
-  if (serv.hnd.fd < 0) {
-    log_emerg("radius:dm_coa: socket: %s\n", strerror(errno));
-    return;
-  }
+	if (serv.hnd.fd < 0) {
+		log_emerg("radius:dm_coa: socket: %s\n", strerror(errno));
+		return;
+	}
 
 	fcntl(serv.hnd.fd, F_SETFD, fcntl(serv.hnd.fd, F_GETFD) | FD_CLOEXEC);
 
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons (conf_dm_coa_port);
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons (conf_dm_coa_port);
 	if (conf_dm_coa_server)
-	  addr.sin_addr.s_addr = conf_dm_coa_server;
+		addr.sin_addr.s_addr = conf_dm_coa_server;
 	else
 		addr.sin_addr.s_addr = htonl (INADDR_ANY);
-  if (bind (serv.hnd.fd, (struct sockaddr *) &addr, sizeof (addr)) < 0) {
-    log_emerg("radius:dm_coa: bind: %s\n", strerror(errno));
+	if (bind (serv.hnd.fd, (struct sockaddr *) &addr, sizeof (addr)) < 0) {
+		log_emerg("radius:dm_coa: bind: %s\n", strerror(errno));
 		close(serv.hnd.fd);
-    return;
-  }
+		return;
+	}
 
 	if (fcntl(serv.hnd.fd, F_SETFL, O_NONBLOCK)) {
-    log_emerg("radius:dm_coa: failed to set nonblocking mode: %s\n", strerror(errno));
+		log_emerg("radius:dm_coa: failed to set nonblocking mode: %s\n", strerror(errno));
 		close(serv.hnd.fd);
-    return;
+		return;
 	}
 
 	triton_context_register(&serv.ctx, NULL);

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -303,6 +303,14 @@ int rad_proc_attrs(struct rad_req_t *req)
 			continue;
 
 		switch(attr->attr->id) {
+			case User_Name:
+				if (rpd->acct_username)
+					_free(rpd->acct_username);
+				if (attr->len)
+					rpd->acct_username = _strndup(attr->val.string, attr->len);
+				else if (rpd->acct_username)
+					rpd->acct_username = NULL;
+				break;
 			case Framed_IP_Address:
 				if (!conf_gw_ip_address && rpd->ses->ctrl->ppp)
 					log_ppp_warn("radius: gw-ip-address not specified, cann't assign IP address...\n");
@@ -663,6 +671,9 @@ static void ses_finished(struct ap_session *ses)
 			rad_req_free(rpd->acct_req);
 		}
 	}
+
+	if (rpd->acct_username)
+		_free(rpd->acct_username);
 
 	if (rpd->auth_reply)
 		rad_packet_free(rpd->auth_reply);

--- a/accel-pppd/radius/radius_p.h
+++ b/accel-pppd/radius/radius_p.h
@@ -67,6 +67,7 @@ struct radius_pd_t {
 	struct ipv6db_prefix_t ipv6_dp;
 	int acct_interim_interval;
 
+	char *acct_username;
 	uint8_t *attr_class;
 	int attr_class_len;
 	uint8_t *attr_state;

--- a/accel-pppd/radius/req.c
+++ b/accel-pppd/radius/req.c
@@ -72,6 +72,9 @@ static struct rad_req_t *__rad_req_alloc(struct radius_pd_t *rpd, int code, cons
 	if (!req->pack)
 		goto out_err;
 
+	if (code == CODE_ACCOUNTING_REQUEST && rpd->acct_username)
+		username = rpd->acct_username;
+
 	if (rad_packet_add_str(req->pack, NULL, "User-Name", username))
 		goto out_err;
 


### PR DESCRIPTION
once radius server has returned User-Name attribute in Access-Accept
packet, it'll be used for any subsequent Accounting-Request packets
instead of internal username per RFC2865 5.1

other way of just replacing session username is possible, but not
desired at the moment due potential issues with single-session modes
in case of different ppp logins / ipoe macs and same contract number
returned by radius for that accounts.

also, add logging & parsing of invalid dm/coa packet for easier debug