### PR TITLE
Added single-session-ignore-case option

### DIFF
--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -37,6 +37,7 @@ thread-count=4
 
 [common]
 #single-session=replace
+#single-session-ignore-case=0
 #sid-case=upper
 #sid-source=seq
 #max-sessions=1000

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -105,6 +105,9 @@ If this option is
 .B deny
 then accel-ppp will deny second session authorization.
 .TP
+.BI "single-session-ignore-case=" 0|1
+Specifies whether accel-ppp should ignore the case when comparing username within single-session validation (default 0).
+.TP
 .BI "sid-case=" upper|lower
 Specifies in which case generate session identifier (default lower).
 .TP


### PR DESCRIPTION
If multisession behavior is managed by accel-ppp and Radius server
ignores the case of the User-Name attribute, it might be required to
ignore the case in accel-ppp to prevent multiple session with
different letter cases.