### PR TITLE
ipoe: dhcpv4: echo back opt82 if sent by client/relay per rfc3046

### DIFF
--- a/accel-pppd/ctrl/ipoe/dhcpv4.c
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.c
@@ -741,7 +741,8 @@ int dhcpv4_send_reply(int msg_type, struct dhcpv4_serv *serv, struct dhcpv4_pack
 
 	if (relay) {
 		list_for_each_entry(opt, &relay->options, entry) {
-			if (opt->type == 53 || opt->type == 54 || opt->type == 51 || opt->type == 58 || opt->type == 1 || (opt->type == 3 && router))
+			if (opt->type == 53 || opt->type == 54 || opt->type == 51 || opt->type == 58 ||
+			    opt->type == 1 || (opt->type == 3 && router) || opt->type == 82)
 				continue;
 			else if (opt->type == 6)
 				dns_avail = 1;
@@ -769,6 +770,9 @@ int dhcpv4_send_reply(int msg_type, struct dhcpv4_serv *serv, struct dhcpv4_pack
 		if (wins_avail && dhcpv4_packet_add_opt(pack, 44, addr, wins_avail * sizeof(addr[0])))
 			goto out_err;
 	}
+
+	if (req->relay_agent && dhcpv4_packet_add_opt(pack, 82, req->relay_agent->data, req->relay_agent->len))
+		goto out_err;
 
 	*pack->ptr++ = 255;
 
@@ -815,6 +819,9 @@ int dhcpv4_send_nak(struct dhcpv4_serv *serv, struct dhcpv4_packet *req)
 
 	val = DHCPNAK;
 	if (dhcpv4_packet_add_opt(pack, 53, &val, 1))
+		goto out_err;
+
+	if (req->relay_agent && dhcpv4_packet_add_opt(pack, 82, req->relay_agent->data, req->relay_agent->len))
 		goto out_err;
 
 	*pack->ptr++ = 255;


### PR DESCRIPTION
there're some onu in the wild, which insert opt82 in relayed requests and drop any unmatching replies (w/o same opt82).
to fix that, need to improve dhcp compliance for following rc3046 parts:

>2.1 Agent Operation
>  The Relay Agent Information option echoed by a server MUST be removed
>   by either the relay agent or the trusted downstream network element
>   which added it when forwarding a server-to-client response back to
>   the client.
>
>2.2 Server Operation
>  DHCP servers claiming to support the Relay Agent Information option
>   SHALL echo the entire contents of the Relay Agent Information option
>   in all replies.  Servers SHOULD copy the Relay Agent Information
>   option as the last DHCP option in the response.
