### PR TITLE
Refresh interface index when moving to another netns

### DIFF
--- a/accel-pppd/ifcfg.c
+++ b/accel-pppd/ifcfg.c
@@ -319,6 +319,9 @@ int __export ap_session_rename(struct ap_session *ses, const char *ifname, int l
 		}
 		ses->net = ns;
 		net = ns;
+
+		/* Refresh the index now that it is in a new namespace */
+		ses->ifindex = net->get_ifindex(ses->ifname);
 		log_ppp_info2("move to namespace %s\n", ns->name);
 	}
 

--- a/accel-pppd/include/ap_net.h
+++ b/accel-pppd/include/ap_net.h
@@ -31,6 +31,7 @@ struct ap_net {
 	void (*rtnl_put)(struct rtnl_handle *);
 	int (*rtnl_open)(struct rtnl_handle *h, int proto);
 	int (*move_link)(struct ap_net *net, int ifindex);
+	int (*get_ifindex)(const char * ifname);
 	void (*release)(struct ap_net *net);
 };
 

--- a/accel-pppd/net.c
+++ b/accel-pppd/net.c
@@ -7,6 +7,7 @@
 #include <sched.h>
 #include <limits.h>
 #include <errno.h>
+#include <linux/if.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <sys/syscall.h>
@@ -215,6 +216,22 @@ static int def_move_link(struct ap_net *new_net, int ifindex)
 #endif
 }
 
+static int def_get_ifindex(const char *ifname)
+{
+	struct kern_net *n = container_of(net, typeof(*n), net);
+	struct ifreq ifr;
+
+	memset(&ifr, 0, sizeof(ifr));
+	strcpy(ifr.ifr_name, ifname);
+
+	if (ioctl(n->sock, SIOCGIFINDEX, &ifr)) {
+		log_ppp_error("ioctl(SIOCGIFINDEX): %s\n", strerror(errno));
+		return -1;
+	}
+	return ifr.ifr_ifindex;
+}
+
+
 static void def_release(struct ap_net *d)
 {
 	struct kern_net *n = container_of(d, typeof(*n), net);
@@ -299,6 +316,7 @@ static struct ap_net *alloc_net(const char *name)
 	net->rtnl_put = def_rtnl_put;
 	net->rtnl_open = def_rtnl_open;
 	net->move_link = def_move_link;
+	net->get_ifindex = def_get_ifindex;
 	net->release = def_release;
 
 	n->sock = socket(AF_INET, SOCK_DGRAM, 0);

--- a/accel-pppd/ppp/ppp.c
+++ b/accel-pppd/ppp/ppp.c
@@ -280,6 +280,7 @@ static void destablish_ppp(struct ppp_t *ppp)
 			}
 			ppp->ses.net = def_net;
 			net = def_net;
+			ppp->ses.ifindex = net->get_ifindex(ppp->ses.ifname);
 		}
 
 		sprintf(ifr.ifr_newname, "ppp%i", ppp->ses.unit_idx);

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -88,21 +88,11 @@ void __export ap_session_set_ifindex(struct ap_session *ses)
 
 int __export ap_session_starting(struct ap_session *ses)
 {
-	struct ifreq ifr;
-
 	if (ap_shutdown)
 		return -1;
 
-	if (ses->ifindex == -1 && ses->ifname[0]) {
-		memset(&ifr, 0, sizeof(ifr));
-		strcpy(ifr.ifr_name, ses->ifname);
-
-		if (net->sock_ioctl(SIOCGIFINDEX, &ifr)) {
-			log_ppp_error("ioctl(SIOCGIFINDEX): %s\n", strerror(errno));
-			return -1;
-		}
-		ses->ifindex = ifr.ifr_ifindex;
-	}
+	if (ses->ifindex == -1 && ses->ifname[0])
+		ses->ifindex = net->get_ifindex(ses->ifname);
 
 	if (ses->ifindex != -1)
 		ap_session_set_ifindex(ses);


### PR DESCRIPTION
When a network interface is moved to another network namespace, it might be reindexed if its current index conflicts with one already used in the new namespace. This patchset refreshes our record of the index any time we move the interface around.