### PR TITLE
Fix accel-cmd compile problem on Raspbian Buster

### DIFF
--- a/accel-cmd/accel_cmd.c
+++ b/accel-cmd/accel_cmd.c
@@ -645,7 +645,7 @@ int main(int argc, char **argv)
 	bool numeric = false;
 	int inputstream = -1;
 	int oindx = 0;
-	char ochar;
+	int ochar;
 	int rv;
 
 	while ((ochar = getopt_long(argc, argv, "f:46ni:H:p:t:P:vVh-",


### PR DESCRIPTION
With GCC v8.x on Raspbian Buster the following warning is shown
at compile time:

...
[ 99%] Building C object accel-cmd/CMakeFiles/accel-cmd.dir/accel_cmd.c.o
/home/pi/accel-ppp/accel-cmd/accel_cmd.c: In function ‘main’:
/home/pi/accel-ppp/accel-cmd/accel_cmd.c:652:29: warning: comparison is always true due to limited range of data type [-Wtype-limits]
         long_opts, &oindx)) != -1) {
                             ^~
[100%] Linking C executable accel-cmd
[100%] Built target accel-cmd

This leads to the accel-cmd always just showing the usage
instructions rather than executing any commands.

This is because ochar is declared as a char rather than an int
so is considered to be unsigned by default. The man page says
the return value should be an int.

https://linux.die.net/man/3/getopt_long