### PR TITLE
WIP: Fix radius Framed-IP-Address

### DIFF
--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -78,7 +78,6 @@ verbose=1
 
 [pppoe]
 verbose=1
-#max-starting=0
 #ac-name=xxx
 #service-name=yyy
 #pado-delay=0

--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -68,7 +68,6 @@ unit-cache=1
 #noauth=0
 
 [pptp]
-#max-starting=0
 verbose=1
 #echo-interval=30
 #ip-pool=pptp
@@ -139,7 +138,6 @@ verbose=1
 #ifname=sstp%d
 
 [ipoe]
-#max-starting=0
 verbose=1
 username=ifname
 #password=username

--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -41,6 +41,7 @@ thread-count=4
 #sid-case=upper
 #sid-source=seq
 #max-sessions=1000
+#max-starting=0
 #check-ip=0
 
 [ppp]

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -124,7 +124,10 @@ Assign session id by sequence method
 Path to file for sessions sequence number. Start sequence number may be set there (default /var/lib/accel-ppp/seq).
 .TP
 .BI "max-sessions=" n
-Specifies maximum sessions which server may processed (default 0, disabled)
+Specifies maximum concurrent sessions which server may processed (default 0, disabled)
+.TP
+.BI "max-starting=" n
+Specifies maximum concurrent session attempts which server may processed (default 0, disabled)
 .TP
 .BI "check-ip=" 0|1
 Specifies whether accel-ppp should check if IP already assigned to other client interface (default 0).

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -127,7 +127,6 @@ static int conf_username;
 static const char *conf_password;
 static int conf_unit_cache;
 static int conf_noauth;
-static int conf_max_starting;
 #ifdef RADIUS
 static int conf_vendor;
 static const char *conf_vendor_str;
@@ -1772,10 +1771,7 @@ static void __ipoe_recv_dhcpv4(struct dhcpv4_serv *dhcpv4, struct dhcpv4_packet 
 
 	if (connlimit_loaded && pack->msg_type == DHCPDISCOVER && connlimit_check(serv->opt_shared ? cl_key_from_mac(pack->hdr->chaddr) : serv->ifindex))
 		return;
-	if (conf_max_starting > 0 && pack->msg_type == DHCPDISCOVER && stat_starting > conf_max_starting) {
-		log_warn("ipoe: Count of starting sessions  > conf_max_starting, droping connection...\n");
-		return;
-	}
+
 	pthread_mutex_lock(&serv->lock);
 	if (pack->msg_type == DHCPDISCOVER) {
 		if (check_notify(serv, pack))
@@ -2031,10 +2027,7 @@ static struct ipoe_session *ipoe_session_create_up(struct ipoe_serv *serv, struc
 
 	if (connlimit_loaded && connlimit_check(cl_key_from_ipv4(saddr)))
 		return NULL;
-	if (conf_max_starting > 0 && stat_starting > conf_max_starting) {
-		log_warn("ipoe: Count of starting sessions  >  conf_max_starting, droping connection...\n");
-		return NULL;
-	}
+
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)
 		return NULL;
 
@@ -3745,11 +3738,6 @@ static void load_config(void)
 			conf_password = opt;
 	} else
 		conf_password = NULL;
-	opt = conf_get_opt("ipoe", "max-starting");
-	if (opt)
-		conf_max_starting = atoi(opt);
-	else
-		conf_max_starting = 0;
 
 	opt = conf_get_opt("ipoe", "netmask");
 	if (opt) {

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -1302,6 +1302,9 @@ static struct ipoe_session *ipoe_session_create_dhcpv4(struct ipoe_serv *serv, s
 	if (ap_shutdown)
 		return NULL;
 
+	if (conf_max_starting && ap_session_stat.starting >= conf_max_starting)
+		return NULL;
+
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)
 		return NULL;
 
@@ -2025,10 +2028,13 @@ static struct ipoe_session *ipoe_session_create_up(struct ipoe_serv *serv, struc
 	if (ap_shutdown)
 		return NULL;
 
-	if (connlimit_loaded && connlimit_check(cl_key_from_ipv4(saddr)))
+	if (conf_max_starting && ap_session_stat.starting >= conf_max_starting)
 		return NULL;
 
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)
+		return NULL;
+
+	if (connlimit_loaded && connlimit_check(cl_key_from_ipv4(saddr)))
 		return NULL;
 
 	if (l4_redirect_list_check(saddr))

--- a/accel-pppd/ctrl/l2tp/l2tp.c
+++ b/accel-pppd/ctrl/l2tp/l2tp.c
@@ -2761,6 +2761,9 @@ static int l2tp_recv_SCCRQ(const struct l2tp_serv_t *serv,
 		return 0;
 	}
 
+	if (conf_max_starting && ap_session_stat.starting >= conf_max_starting)
+		return 0;
+
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)
 		return 0;
 
@@ -3300,6 +3303,9 @@ static int l2tp_recv_ICRQ(struct l2tp_conn_t *conn,
 		return 0;
 	}
 
+	if (conf_max_starting && ap_session_stat.starting >= conf_max_starting)
+		return 0;
+
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)
 		return 0;
 
@@ -3602,6 +3608,9 @@ static int l2tp_recv_OCRQ(struct l2tp_conn_t *conn,
 			   " discarding OCRQ\n");
 		return 0;
 	}
+
+	if (conf_max_starting && ap_session_stat.starting >= conf_max_starting)
+		return 0;
 
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)
 		return 0;

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -966,6 +966,9 @@ static void pppoe_recv_PADI(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 	if (ap_shutdown || pado_delay == -1)
 		return;
 
+	if (conf_max_starting && ap_session_stat.starting >= conf_max_starting)
+		return;
+
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)
 		return;
 
@@ -1091,6 +1094,9 @@ static void pppoe_recv_PADR(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 	__sync_add_and_fetch(&stat_PADR_recv, 1);
 
 	if (ap_shutdown)
+		return;
+
+	if (conf_max_starting && ap_session_stat.starting >= conf_max_starting)
 		return;
 
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -87,7 +87,6 @@ struct iplink_arg {
 	long *arg1;
 };
 
-static int conf_max_starting;
 int conf_verbose;
 char *conf_service_name[255];
 int conf_accept_any_service;
@@ -969,13 +968,6 @@ static void pppoe_recv_PADI(struct pppoe_serv_t *serv, uint8_t *pack, int size)
 
 	if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions)
 		return;
-	if (conf_max_starting > 0 && stat_starting >= conf_max_starting) {
-		log_warn("pppoe: Count of starting sessions  >  conf_max_starting, droping connection...\n");
-		return;
-
-	}
-
-
 
 	if (check_padi_limit(serv, ethhdr->h_source)) {
 		__sync_add_and_fetch(&stat_PADI_drop, 1);
@@ -1935,12 +1927,6 @@ static void load_config(void)
 {
 	char *opt;
 	struct conf_sect_t *s = conf_get_section("pppoe");
-
-	opt = conf_get_opt("pppoe", "max-starting");
-	if (opt)
-		conf_max_starting = atoi(opt);
-	else
-		conf_max_starting = 0;
 
 	opt = conf_get_opt("pppoe", "verbose");
 	if (opt)

--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -55,7 +55,6 @@ struct pptp_conn_t
 	struct ppp_t ppp;
 };
 
-static int conf_max_starting;
 static int conf_ppp_max_mtu = PPTP_MAX_MTU;
 static int conf_timeout = 5;
 static int conf_echo_interval = 0;
@@ -656,11 +655,6 @@ static int pptp_connect(struct triton_md_handler_t *h)
 			close(sock);
 			continue;
 		}
-		if (conf_max_starting > 0 && stat_starting >= conf_max_starting) {
-			close(sock);
-			log_warn("pptp: Count of starting sessions  >  conf_max_starting, droping connection...\n");
-			continue;
-		}
 
 		if (triton_module_loaded("connlimit") && connlimit_check(cl_key_from_ipv4(addr.sin_addr.s_addr))) {
 			close(sock);
@@ -789,11 +783,6 @@ static void load_config(void)
 	else
 		conf_ppp_max_mtu = PPTP_MAX_MTU;
 
-	opt = conf_get_opt("pptp", "max-starting");
-	if (opt)
-		conf_max_starting = atoi(opt);
-	else
-		conf_max_starting = 0;
 	conf_mppe = MPPE_UNSET;
 	opt = conf_get_opt("pptp", "mppe");
 	if (opt) {

--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -651,6 +651,11 @@ static int pptp_connect(struct triton_md_handler_t *h)
 			continue;
 		}
 
+		if (conf_max_starting && ap_session_stat.starting >= conf_max_starting) {
+			close(sock);
+			continue;
+		}
+
 		if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions) {
 			close(sock);
 			continue;

--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -2196,6 +2196,11 @@ static int sstp_connect(struct triton_md_handler_t *h)
 			continue;
 		}
 
+		if (conf_max_starting && ap_session_stat.starting >= conf_max_starting) {
+			close(sock);
+			continue;
+		}
+
 		ip = conf_proxyproto ? INADDR_ANY : sockaddr_ipv4(&addr);
 		if (ip && triton_module_loaded("connlimit") && connlimit_check(cl_key_from_ipv4(ip))) {
 			close(sock);

--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -2201,10 +2201,15 @@ static int sstp_connect(struct triton_md_handler_t *h)
 			continue;
 		}
 
+		if (conf_max_sessions && ap_session_stat.active + ap_session_stat.starting >= conf_max_sessions) {
+			close(sock);
+			continue;
+		}
+
 		ip = conf_proxyproto ? INADDR_ANY : sockaddr_ipv4(&addr);
 		if (ip && triton_module_loaded("connlimit") && connlimit_check(cl_key_from_ipv4(ip))) {
 			close(sock);
-			return 0;
+			continue;
 		}
 
 		sockaddr_ntop(&addr, addr_buf, sizeof(addr_buf), 0);

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -135,6 +135,7 @@ extern int sock6_fd;
 extern int urandom_fd;
 extern struct ap_session_stat ap_session_stat;
 extern int conf_max_sessions;
+extern int conf_max_starting;
 
 void ap_session_init(struct ap_session *ses);
 void ap_session_set_ifindex(struct ap_session *ses);

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -316,7 +316,7 @@ int rad_proc_attrs(struct rad_req_t *req)
 			case Framed_IP_Address:
 				if (!conf_gw_ip_address && rpd->ses->ctrl->ppp)
 					log_ppp_warn("radius: gw-ip-address not specified, cann't assign IP address...\n");
-				else if (attr->val.ipaddr != htonl(0xfffffffe)) {
+				else if (attr->val.ipaddr != 0xfffffffe) {
 					rpd->ipv4_addr.owner = &ipdb;
 					rpd->ipv4_addr.peer_addr = attr->val.ipaddr;
 					rpd->ipv4_addr.addr = rpd->ses->ctrl->ppp ? conf_gw_ip_address : 0;

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -316,7 +316,7 @@ int rad_proc_attrs(struct rad_req_t *req)
 			case Framed_IP_Address:
 				if (!conf_gw_ip_address && rpd->ses->ctrl->ppp)
 					log_ppp_warn("radius: gw-ip-address not specified, cann't assign IP address...\n");
-				else if (attr->val.ipaddr != 0xfffffffe) {
+				else if (attr->val.ipaddr != htonl(0xfffffffe)) {
 					rpd->ipv4_addr.owner = &ipdb;
 					rpd->ipv4_addr.peer_addr = attr->val.ipaddr;
 					rpd->ipv4_addr.addr = rpd->ses->ctrl->ppp ? conf_gw_ip_address : 0;

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -36,6 +36,7 @@ static int conf_sid_source;
 static int conf_seq_save_timeout = 10;
 static const char *conf_seq_file;
 int __export conf_max_sessions;
+int __export conf_max_starting;
 
 pthread_rwlock_t __export ses_lock = PTHREAD_RWLOCK_INITIALIZER;
 __export LIST_HEAD(ses_list);
@@ -542,6 +543,12 @@ static void load_config(void)
 		conf_max_sessions = atoi(opt);
 	else
 		conf_max_sessions = 0;
+
+	opt = conf_get_opt("common", "max-starting");
+	if (opt)
+		conf_max_starting = atoi(opt);
+	else
+		conf_max_starting = 0;
 }
 
 static void init(void)


### PR DESCRIPTION
Replace constant with the explicit conversion from char* to in_addr_t, old constant value was wrong anyway.
See this gist if you need example code: https://gist.github.com/stetsyuk/2514cb066fd44604a2ea4a7481a677b0
Tested on x64, debian 10.
