### PR TITLE
mempool: add some padding to ensure correct alignment

### DIFF
--- a/accel-pppd/triton/mempool.c
+++ b/accel-pppd/triton/mempool.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdalign.h>
 #include <string.h>
 #include <signal.h>
 #include <unistd.h>
@@ -72,7 +73,7 @@ mempool_t __export *mempool_create(int size)
 	p->magic = (uint64_t)random() * (uint64_t)random();
 #endif
 	spinlock_init(&p->lock);
-	p->size = size;
+	p->size = size + alignof(struct _item_t) - size%alignof(struct _item_t);
 
 	spin_lock(&pools_lock);
 	list_add_tail(&p->entry, &pools);


### PR DESCRIPTION
The _item_t structure is 64-bit aligned on 64-bit architectures, whereas
the allocated structures might very well be 32-bit aligned if, for
instance, they only hold integer values. This patch ensures that we
round up the size to a multiple of the natural alignment of the item
structure, thus ensuring that two consecutive items are properly
aligned.

Unaligned access to non-packed structures is undefined behavior.
On Intel processors, unaligned access can result in those accesses
being much slower than normal. On some other architectures, it could
simply crash the program :-).

Caveat: technically, the stdalign.h headers are part of C11