### PR TITLE
Ensure const correctness when reading the configuration

### DIFF
--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -1937,7 +1937,7 @@ static void load_vlan_mon(struct conf_sect_t *sect)
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 	struct conf_sect_t *s = conf_get_section("pppoe");
 
 	opt = conf_get_opt("pppoe", "verbose");

--- a/accel-pppd/ctrl/pptp/pptp.c
+++ b/accel-pppd/ctrl/pptp/pptp.c
@@ -765,7 +765,7 @@ void __export pptp_get_stat(unsigned int **starting, unsigned int **active)
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("pptp", "timeout");
 	if (opt && atoi(opt) > 0)
@@ -824,7 +824,7 @@ static void load_config(void)
 static void pptp_init(void)
 {
 	struct sockaddr_in addr;
-	char *opt;
+	const char *opt;
 	int fd;
 
 	fd = socket(AF_PPPOX, SOCK_STREAM, PX_PROTO_PPTP);

--- a/accel-pppd/ctrl/sstp/sstp.c
+++ b/accel-pppd/ctrl/sstp/sstp.c
@@ -2372,7 +2372,7 @@ static void ssl_load_config(struct sstp_serv_t *serv, const char *servername)
 	SSL_CTX *old_ctx, *ssl_ctx = NULL;
 	X509 *cert = NULL;
 	BIO *in = NULL;
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("sstp", "ssl-pemfile");
 	if (opt) {
@@ -2638,7 +2638,7 @@ void __export sstp_get_stat(unsigned int **starting, unsigned int **active)
 static void load_config(void)
 {
 	int ipmode;
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("sstp", "verbose");
 	if (opt && atoi(opt) >= 0)
@@ -2741,7 +2741,7 @@ static void sstp_init(void)
 	struct sockaddr_t *addr = &serv.addr;
 	struct stat st;
 	int port, value;
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("sstp", "port");
 	if (opt && atoi(opt) > 0)

--- a/accel-pppd/extra/ipv6pool.c
+++ b/accel-pppd/extra/ipv6pool.c
@@ -440,7 +440,8 @@ static void ippool_init2(void)
 	struct conf_sect_t *s = conf_get_section("ipv6-pool");
 	struct conf_option_t *opt;
 	struct ippool_t *pool, *next;
-	char *pool_name, *val;
+	char *pool_name;
+	const char *val;
 	enum ippool_type type;
 #ifdef RADIUS
 	int dppool_attr = 0, ippool_attr = 0;

--- a/accel-pppd/extra/pppd_compat.c
+++ b/accel-pppd/extra/pppd_compat.c
@@ -717,33 +717,28 @@ out:
 	env[n] = NULL;
 }
 
+static const char *get_exec_path(const char *opt_name)
+{
+	const char *opt;
+	opt = conf_get_opt("pppd-compat", "ip-pre-up");
+
+	if (opt && access(opt, R_OK | X_OK)) {
+		log_error("pppd_compat: %s: %s\n", opt, strerror(errno));
+		return NULL;
+	}
+	return opt;
+
+
+}
+
 static void load_config()
 {
 	const char *opt;
 
-	conf_ip_pre_up = conf_get_opt("pppd-compat", "ip-pre-up");
-	if (conf_ip_pre_up && access(conf_ip_pre_up, R_OK | X_OK)) {
-		log_error("pppd_compat: %s: %s\n", conf_ip_pre_up, strerror(errno));
-		conf_ip_pre_up = NULL;
-	}
-
-	conf_ip_up = conf_get_opt("pppd-compat", "ip-up");
-	if (conf_ip_up && access(conf_ip_up, R_OK | X_OK)) {
-		log_error("pppd_compat: %s: %s\n", conf_ip_up, strerror(errno));
-		conf_ip_up = NULL;
-	}
-
-	conf_ip_down = conf_get_opt("pppd-compat", "ip-down");
-	if (conf_ip_down && access(conf_ip_down, R_OK | X_OK)) {
-		log_error("pppd_compat: %s: %s\n", conf_ip_down, strerror(errno));
-		conf_ip_down = NULL;
-	}
-
-	conf_ip_change = conf_get_opt("pppd-compat", "ip-change");
-	if (conf_ip_change && access(conf_ip_change, R_OK | X_OK)) {
-		log_error("pppd_compat: %s: %s\n", conf_ip_change, strerror(errno));
-		conf_ip_change = NULL;
-	}
+	conf_ip_pre_up = get_exec_path("ip-pre-up");
+	conf_ip_up = get_exec_path("ip-up");
+	conf_ip_down = get_exec_path("ip-down");
+	conf_ip_change = get_exec_path("ip-change");
 
 	conf_radattr_prefix = conf_get_opt("pppd-compat", "radattr-prefix");
 

--- a/accel-pppd/extra/pppd_compat.c
+++ b/accel-pppd/extra/pppd_compat.c
@@ -32,11 +32,11 @@
 #define ENV_MEM 1024
 #define ENV_MAX 16
 
-static char *conf_ip_up;
-static char *conf_ip_pre_up;
-static char *conf_ip_down;
-static char *conf_ip_change;
-static char *conf_radattr_prefix;
+static const char *conf_ip_up;
+static const char *conf_ip_pre_up;
+static const char *conf_ip_down;
+static const char *conf_ip_change;
+static const char *conf_radattr_prefix;
 static int conf_verbose = 0;
 static int conf_fork_limit;
 

--- a/accel-pppd/extra/pppd_compat.c
+++ b/accel-pppd/extra/pppd_compat.c
@@ -65,8 +65,8 @@ struct pppd_compat_pd
 };
 
 static struct pppd_compat_pd *find_pd(struct ap_session *ses);
-static void fill_argv(char **argv, struct pppd_compat_pd *pd, char *path);
-static void fill_env(char **env, char *mem, struct pppd_compat_pd *pd);
+static void fill_argv(const char **argv, struct pppd_compat_pd *pd, const char *path, char *addr_buf, char *peer_buf);
+static void fill_env(const char **env, char *mem, struct pppd_compat_pd *pd);
 #ifdef RADIUS
 static void remove_radattr(struct pppd_compat_pd *);
 static void write_radattr(struct pppd_compat_pd *, struct rad_packet_t *pack);
@@ -119,7 +119,6 @@ static void check_fork_limit(struct pppd_compat_pd *pd, struct list_head *queue)
 		pthread_mutex_unlock(&queue_lock);
 	}
 }
-
 
 static void ip_pre_up_handler(struct sigchld_handler_t *h, int status)
 {
@@ -202,8 +201,8 @@ static void ev_ses_starting(struct ap_session *ses)
 static void ev_ses_pre_up(struct ap_session *ses)
 {
 	pid_t pid;
-	char *argv[8];
-	char *env[ENV_MAX];
+	const char *argv[8];
+	const char *env[ENV_MAX];
 	char env_mem[ENV_MEM];
 	char ipaddr[17];
 	char peer_ipaddr[17];
@@ -236,9 +235,7 @@ static void ev_ses_pre_up(struct ap_session *ses)
 	if (!conf_ip_pre_up)
 		return;
 
-	argv[4] = ipaddr;
-	argv[5] = peer_ipaddr;
-	fill_argv(argv, pd, conf_ip_pre_up);
+	fill_argv(argv, pd, conf_ip_pre_up, ipaddr, peer_ipaddr);
 
 	fill_env(env, env_mem, pd);
 
@@ -270,7 +267,7 @@ static void ev_ses_pre_up(struct ap_session *ses)
 		pthread_sigmask(SIG_UNBLOCK, &set, NULL);
 
 		net->enter_ns();
-		execve(conf_ip_pre_up, argv, env);
+		execve(conf_ip_pre_up, (char **)argv, (char **)env);
 		net->exit_ns();
 
 		log_emerg("pppd_compat: exec '%s': %s\n", conf_ip_pre_up, strerror(errno));
@@ -286,8 +283,8 @@ static void ev_ses_pre_up(struct ap_session *ses)
 static void ev_ses_started(struct ap_session *ses)
 {
 	pid_t pid;
-	char *argv[8];
-	char *env[ENV_MAX];
+	const char *argv[8];
+	const char *env[ENV_MAX];
 	char env_mem[ENV_MEM];
 	char ipaddr[17];
 	char peer_ipaddr[17];
@@ -302,9 +299,7 @@ static void ev_ses_started(struct ap_session *ses)
 	if (!conf_ip_up)
 		return;
 
-	argv[4] = ipaddr;
-	argv[5] = peer_ipaddr;
-	fill_argv(argv, pd, conf_ip_up);
+	fill_argv(argv, pd, conf_ip_up, ipaddr, peer_ipaddr);
 
 	fill_env(env, env_mem, pd);
 
@@ -324,7 +319,7 @@ static void ev_ses_started(struct ap_session *ses)
 		pthread_sigmask(SIG_UNBLOCK, &set, NULL);
 
 		net->enter_ns();
-		execve(conf_ip_up, argv, env);
+		execve(conf_ip_up, (char **)argv, (char **)env);
 		net->exit_ns();
 
 		log_emerg("pppd_compat: exec '%s': %s\n", conf_ip_up, strerror(errno));
@@ -339,8 +334,8 @@ static void ev_ses_started(struct ap_session *ses)
 static void ev_ses_finished(struct ap_session *ses)
 {
 	pid_t pid;
-	char *argv[8];
-	char *env[ENV_MAX];
+	const char *argv[8];
+	const char *env[ENV_MAX];
 	char env_mem[ENV_MEM];
 	char ipaddr[17];
 	char peer_ipaddr[17];
@@ -359,9 +354,7 @@ static void ev_ses_finished(struct ap_session *ses)
 	}
 
 	if (pd->started && conf_ip_down) {
-		argv[4] = ipaddr;
-		argv[5] = peer_ipaddr;
-		fill_argv(argv, pd, conf_ip_down);
+		fill_argv(argv, pd, conf_ip_down, ipaddr, peer_ipaddr);
 
 		fill_env(env, env_mem, pd);
 
@@ -387,7 +380,7 @@ static void ev_ses_finished(struct ap_session *ses)
 			pthread_sigmask(SIG_UNBLOCK, &set, NULL);
 
 			net->enter_ns();
-			execve(conf_ip_down, argv, env);
+			execve(conf_ip_down, (char **)argv, (char **)env);
 			net->exit_ns();
 
 			log_emerg("pppd_compat: exec '%s': %s\n", conf_ip_down, strerror(errno));
@@ -439,8 +432,8 @@ static void ev_radius_access_accept(struct ev_radius_t *ev)
 static void ev_radius_coa(struct ev_radius_t *ev)
 {
 	pid_t pid;
-	char *argv[8];
-	char *env[ENV_MAX];
+	const char *argv[8];
+	const char *env[ENV_MAX];
 	char env_mem[ENV_MEM];
 	char ipaddr[17];
 	char peer_ipaddr[17];
@@ -457,7 +450,7 @@ static void ev_radius_coa(struct ev_radius_t *ev)
 	if (conf_ip_change) {
 		argv[4] = ipaddr;
 		argv[5] = peer_ipaddr;
-		fill_argv(argv, pd, conf_ip_change);
+		fill_argv(argv, pd, conf_ip_change, ipaddr, peer_ipaddr);
 
 		fill_env(env, env_mem, pd);
 
@@ -479,7 +472,7 @@ static void ev_radius_coa(struct ev_radius_t *ev)
 				ev->res = pd->res;
 		} else if (pid == 0) {
 			net->enter_ns();
-			execve(conf_ip_change, argv, env);
+			execve(conf_ip_change, (char **)argv, (char **)env);
 			net->exit_ns();
 
 			log_emerg("pppd_compat: exec '%s': %s\n", conf_ip_change, strerror(errno));
@@ -599,19 +592,21 @@ static struct pppd_compat_pd *find_pd(struct ap_session *ses)
 	return NULL;
 }
 
-static void fill_argv(char **argv, struct pppd_compat_pd *pd, char *path)
+static void fill_argv(const char **argv, struct pppd_compat_pd *pd, const char *path, char *addr_buf, char *peer_buf)
 {
+	u_inet_ntoa(pd->ipv4_addr, addr_buf);
+	u_inet_ntoa(pd->ipv4_peer_addr, peer_buf);
 	argv[0] = path;
 	argv[1] = pd->ses->ifname;
 	argv[2] = "none";
 	argv[3] = "0";
-	u_inet_ntoa(pd->ipv4_addr, argv[4]);
-	u_inet_ntoa(pd->ipv4_peer_addr, argv[5]);
+	argv[4] = addr_buf;
+	argv[5] = peer_buf;
 	argv[6] = pd->ses->ctrl->calling_station_id;
 	argv[7] = NULL;
 }
 
-static void fill_env(char **env, char *mem, struct pppd_compat_pd *pd)
+static void fill_env(const char **env, char *mem, struct pppd_compat_pd *pd)
 {
 	struct ap_session *ses = pd->ses;
 	size_t mem_sz = ENV_MEM;

--- a/accel-pppd/log.c
+++ b/accel-pppd/log.c
@@ -490,7 +490,7 @@ static void sighup(int n)
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("log", "level");
 	if (opt && atoi(opt) >= 0)

--- a/accel-pppd/ppp/ipcp_opt_dns.c
+++ b/accel-pppd/ppp/ipcp_opt_dns.c
@@ -162,7 +162,7 @@ static void ev_dns(struct ev_dns_t *ev)
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("dns", "dns1");
 	if (opt)

--- a/accel-pppd/ppp/ipcp_opt_wins.c
+++ b/accel-pppd/ppp/ipcp_opt_wins.c
@@ -162,7 +162,7 @@ static void ev_wins(struct ev_wins_t *ev)
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("wins", "wins1");
 	if (opt)

--- a/accel-pppd/ppp/lcp_opt_accomp.c
+++ b/accel-pppd/ppp/lcp_opt_accomp.c
@@ -137,7 +137,7 @@ static void accomp_print(void (*print)(const char *fmt, ...), struct lcp_option_
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("ppp", "accomp");
 	if (opt) {

--- a/accel-pppd/ppp/lcp_opt_mru.c
+++ b/accel-pppd/ppp/lcp_opt_mru.c
@@ -161,7 +161,7 @@ static void mru_print(void (*print)(const char *fmt, ...), struct lcp_option_t *
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("ppp", "mtu");
 	if (opt && atoi(opt) > 0)

--- a/accel-pppd/ppp/lcp_opt_pcomp.c
+++ b/accel-pppd/ppp/lcp_opt_pcomp.c
@@ -137,7 +137,7 @@ static void pcomp_print(void (*print)(const char *fmt, ...), struct lcp_option_t
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("ppp", "pcomp");
 	if (opt) {

--- a/accel-pppd/ppp/ppp_fsm.c
+++ b/accel-pppd/ppp/ppp_fsm.c
@@ -528,7 +528,7 @@ static void restart_timer_func(struct triton_timer_t *t)
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("ppp", "max-terminate");
 	if (opt && atoi(opt) > 0)

--- a/accel-pppd/ppp/ppp_ipcp.c
+++ b/accel-pppd/ppp/ppp_ipcp.c
@@ -556,7 +556,7 @@ static int ipcp_recv_conf_nak(struct ppp_ipcp_t *ipcp, uint8_t *data, int size)
 					lopt->h->print(log_ppp_info2,lopt,data);
 				}
 				if (lopt->h->recv_conf_nak && lopt->h->recv_conf_nak(ipcp, lopt, data))
-					res =- 1;
+					res = -1;
 				break;
 			}
 		}

--- a/accel-pppd/ppp/ppp_ipv6cp.c
+++ b/accel-pppd/ppp/ppp_ipv6cp.c
@@ -556,7 +556,7 @@ static int ipv6cp_recv_conf_nak(struct ppp_ipv6cp_t *ipv6cp, uint8_t *data, int 
 					lopt->h->print(log_ppp_info2,lopt,data);
 				}
 				if (lopt->h->recv_conf_nak && lopt->h->recv_conf_nak(ipv6cp, lopt, data))
-					res =- 1;
+					res = -1;
 				break;
 			}
 		}

--- a/accel-pppd/ppp/ppp_lcp.c
+++ b/accel-pppd/ppp/ppp_lcp.c
@@ -881,7 +881,7 @@ static struct ppp_layer_t lcp_layer=
 
 static void load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("ppp", "lcp-echo-interval");
 	if (opt)

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -913,7 +913,7 @@ static int parse_server(const char *opt, in_addr_t *addr, int *port, char **secr
 
 static int load_config(void)
 {
-	char *opt;
+	const char *opt;
 
 	opt = conf_get_opt("radius", "max-try");
 	if (opt && atoi(opt) > 0)

--- a/accel-pppd/triton/conf_file.c
+++ b/accel-pppd/triton/conf_file.c
@@ -138,7 +138,8 @@ static int load_file(struct conf_ctx *ctx)
 					fprintf(stderr, "conf_file:%s:%i: parent option not found\n", ctx->fname, ctx->line);
 					return -1;
 				}
-				str2 = opt->val;
+				/* We're still in the building phase, disregard the const correctness */
+				str2 = (char *)opt->val;
 			}
 		} else
 			str2 = NULL;
@@ -203,9 +204,9 @@ static void free_items(struct list_head *items)
 		opt = list_entry(items->next, typeof(*opt), entry);
 		list_del(&opt->entry);
 		if (opt->val)
-			_free(opt->val);
-		_free(opt->name);
-		_free(opt->raw);
+			_free((char *)opt->val);
+		_free((char *)opt->name);
+		_free((char *)opt->raw);
 		free_items(&opt->items);
 		_free(opt);
 	}
@@ -322,7 +323,7 @@ __export struct conf_sect_t * conf_get_section(const char *name)
 	return find_sect(name);
 }
 
-__export char * conf_get_opt(const char *sect, const char *name)
+__export const char * conf_get_opt(const char *sect, const char *name)
 {
 	struct conf_option_t *opt;
 	struct conf_sect_t *s = conf_get_section(sect);

--- a/accel-pppd/triton/loader.c
+++ b/accel-pppd/triton/loader.c
@@ -24,7 +24,7 @@ int load_modules(const char *name)
 	struct conf_sect_t *sect;
 	struct conf_option_t *opt;
 	char *fname;
-	char *path = MODULE_PATH;
+	const char *path = MODULE_PATH;
 	char *ptr1, *ptr2;
 	struct module_t *m;
 	void *h;

--- a/accel-pppd/triton/log.c
+++ b/accel-pppd/triton/log.c
@@ -12,8 +12,8 @@ static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
 int log_init(void)
 {
-	char *log_error = conf_get_opt("core","log-error");
-	char *log_debug = conf_get_opt("core","log-debug");
+	const char *log_error = conf_get_opt("core","log-error");
+	const char *log_debug = conf_get_opt("core","log-debug");
 
 	if (log_error) {
 		f_error = fopen(log_error, "a");

--- a/accel-pppd/triton/triton.c
+++ b/accel-pppd/triton/triton.c
@@ -724,7 +724,7 @@ void __export triton_run()
 {
 	struct _triton_thread_t *t;
 	int i;
-	char *opt;
+	const char *opt;
 	struct timespec ts;
 
 	opt = conf_get_opt("core", "thread-count");

--- a/accel-pppd/triton/triton.h
+++ b/accel-pppd/triton/triton.h
@@ -41,9 +41,9 @@ struct triton_sigchld_handler_t
 struct conf_option_t
 {
 	struct list_head entry;
-	char *name;
-	char *val;
-	char *raw;
+	const char *name;
+	const char *val;
+	const char *raw;
 	struct list_head items;
 };
 
@@ -101,7 +101,7 @@ int triton_event_register_handler(int ev_id, triton_event_func func);
 void triton_event_fire(int ev_id, void *arg);
 
 struct conf_sect_t *conf_get_section(const char *name);
-char *conf_get_opt(const char *sect, const char *name);
+const char *conf_get_opt(const char *sect, const char *name);
 void triton_conf_reload(void (*notify)(int));
 
 void triton_collect_cpu_usage(void);


### PR DESCRIPTION
As they say, "shared mutable state is the root of all evil". This patch series clearly marks the triton code as the owner of the configuration objects, making their content internal. Most of the changes are simply changing the client code to use the proper type, with the exception of pppd_compat.

There, the changes are a bit more involved, as the `const char *` pointers end up being fed to an API that takes in `char *` arguments for historical reasons. Detailed explanations can be found in the commit logs.