### PR TITLE
Radius radacct avp

### DIFF
--- a/accel-pppd/radius/packet.c
+++ b/accel-pppd/radius/packet.c
@@ -325,6 +325,9 @@ void rad_packet_print(struct rad_packet_t *pack, struct rad_server_t *s, void (*
 	else
 		print("[RADIUS ");
 
+	if (!pack)
+		return;
+
 	switch(pack->code) {
 		case CODE_ACCESS_REQUEST:
 			print("Access-Request");

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -42,6 +42,7 @@ int conf_sid_in_auth;
 int conf_require_nas_ident;
 int conf_acct_interim_interval;
 int conf_acct_interim_jitter;
+int conf_send_auth_reply_attr_acct;
 
 int conf_accounting;
 int conf_fail_time;
@@ -966,6 +967,12 @@ static int load_config(void)
 	opt = conf_get_opt("radius", "acct-timeout");
 	if (opt && atoi(opt) >= 0)
 		conf_acct_timeout = atoi(opt);
+
+	opt = conf_get_opt("radius", "send-auth-reply-attr-acct");
+	if (opt && atoi(opt) >= 0)
+		conf_send_auth_reply_attr_acct = atoi(opt) > 0;
+	else
+		conf_send_auth_reply_attr_acct = 0;
 
 	opt = conf_get_opt("radius", "verbose");
 	if (opt && atoi(opt) >= 0)

--- a/accel-pppd/radius/radius_p.h
+++ b/accel-pppd/radius/radius_p.h
@@ -188,6 +188,7 @@ extern int conf_dm_coa_port;
 extern int conf_acct_interim_interval;
 extern int conf_acct_interim_jitter;
 extern int conf_accounting;
+extern int conf_send_auth_reply_attr_acct;
 extern const char *conf_attr_tunnel_type;
 
 int rad_check_nas_pack(struct rad_packet_t *pack);

--- a/accel-pppd/radius/req.c
+++ b/accel-pppd/radius/req.c
@@ -24,6 +24,7 @@ static struct rad_req_t *__rad_req_alloc(struct radius_pd_t *rpd, int code, cons
 	struct ppp_t *ppp = NULL;
 	struct rad_req_t *req = mempool_alloc(req_pool);
 	struct timespec ts;
+        struct rad_attr_t *attr;
 
 	if (!req) {
 		log_emerg("radius: out of memory\n");
@@ -121,6 +122,15 @@ static struct rad_req_t *__rad_req_alloc(struct radius_pd_t *rpd, int code, cons
 	if (conf_attr_tunnel_type)
 		if (rad_packet_add_str(req->pack, NULL, conf_attr_tunnel_type, rpd->ses->ctrl->name))
 			goto out_err;
+
+	if (code == CODE_ACCOUNTING_REQUEST && rpd->auth_reply && conf_send_auth_reply_attr_acct) 
+	{
+		list_for_each_entry(attr, &rpd->auth_reply->attrs, entry) {
+			if (attr && attr->vendor && attr->vendor->name && attr->attr && attr->attr->name && attr->val.string)
+				if (rad_packet_add_str(req->pack, attr->vendor->name, attr->attr->name, attr->val.string))
+					log_ppp_error("Could not add reply attribute %s to Accounting-Start request", attr->attr->name);
+		}
+	}
 
 	list_for_each_entry(plugin, &req->rpd->plugin_list, entry) {
 		switch (code) {


### PR DESCRIPTION
This pull contains a feature where AVPs received from the RADIUS server on an Auth-Reply are then sent to the RADIUS server as part of the Accounting-Request. This is useful for a variety of reasons in a number of scenarios such as profile management, etc.