### PR TITLE
Add missing dhcp end option on dhcp notify packet

### DIFF
--- a/accel-pppd/ctrl/ipoe/dhcpv4.c
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.c
@@ -925,6 +925,8 @@ void dhcpv4_send_notify(struct dhcpv4_serv *serv, struct dhcpv4_packet *req, uns
 	dhcpv4_packet_add_opt_u8(pack, 53, DHCPDISCOVER);
 	dhcpv4_packet_add_opt(pack, 43, opt, sizeof(opt));
 
+	*pack->ptr++ = 255;
+
 	dhcpv4_send_raw(serv, pack, 0, INADDR_BROADCAST, DHCP_SERV_PORT);
 
 	dhcpv4_packet_free(pack);


### PR DESCRIPTION
The DHCP Notify Packet send out for the load balancing mechanism (weight) is lacking a DHCP End Option (255). For accel-ppp this is not an issue, since the only consumer of this packet should be other accel-ppp Hosts.

Our Ruckus ICX Switches try to parse these packets with activated DHCP Snooping function resulting in some critical errors on the Switch CLI:

`DHCP Option82: WARNING: No END OPTION found before bounds.`

So this looks really bad and fixing is easy by adding the DHCP Option 255 end marker.