### PR TITLE
DHCP Option 82 Subscriber-ID

### DIFF
--- a/accel-pppd/ctrl/ipoe/dhcpv4.c
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.c
@@ -430,7 +430,7 @@ void dhcpv4_packet_free(struct dhcpv4_packet *pack)
 	mempool_free(pack);
 }
 
-int dhcpv4_parse_opt82(struct dhcpv4_option *opt, uint8_t **agent_circuit_id, uint8_t **agent_remote_id)
+int dhcpv4_parse_opt82(struct dhcpv4_option *opt, uint8_t **agent_circuit_id, uint8_t **agent_remote_id, uint8_t **subscriber_id)
 {
 	uint8_t *ptr = opt->data;
 	uint8_t *endptr = ptr + opt->len;
@@ -450,6 +450,8 @@ int dhcpv4_parse_opt82(struct dhcpv4_option *opt, uint8_t **agent_circuit_id, ui
 			*agent_circuit_id = ptr - 1;
 		else if (type == 2)
 			*agent_remote_id = ptr - 1;
+		else if (type == 6)
+			*subscriber_id = ptr - 1;
 
 		ptr += len;
 	}

--- a/accel-pppd/ctrl/ipoe/dhcpv4.h
+++ b/accel-pppd/ctrl/ipoe/dhcpv4.h
@@ -136,7 +136,7 @@ void dhcpv4_print_options(struct dhcpv4_packet *, void (*)(const char *, ...));
 
 void dhcpv4_print_packet(struct dhcpv4_packet *pack, int relay, void (*print)(const char *fmt, ...));
 
-int dhcpv4_parse_opt82(struct dhcpv4_option *opt, uint8_t **agent_circuit_id, uint8_t **agent_remote_id);
+int dhcpv4_parse_opt82(struct dhcpv4_option *opt, uint8_t **agent_circuit_id, uint8_t **agent_remote_id, uint8_t **subscriber_id);
 
 int dhcpv4_get_ip(struct dhcpv4_serv *serv, uint32_t *yiaddr, uint32_t *siaddr, int *mask);
 void dhcpv4_put_ip(struct dhcpv4_serv *serv, uint32_t ip);

--- a/accel-pppd/ctrl/ipoe/dhcpv4_options.c
+++ b/accel-pppd/ctrl/ipoe/dhcpv4_options.c
@@ -231,6 +231,8 @@ static void print_relay_agent(const struct dhcpv4_option *opt, int elem_size, vo
 			print("{Agent-Circuit-ID ");
 		else if (type == 2)
 			print("{Agent-Remote-ID ");
+		else if (type == 6)
+			print("{Subscriber-ID ");
 		else
 			print("{Option-%i ", type);
 

--- a/accel-pppd/ctrl/ipoe/ipoe.c
+++ b/accel-pppd/ctrl/ipoe/ipoe.c
@@ -258,6 +258,7 @@ static struct ipoe_session *ipoe_session_lookup(struct ipoe_serv *serv, struct d
 
 	uint8_t *agent_circuit_id = NULL;
 	uint8_t *agent_remote_id = NULL;
+	uint8_t *subscriber_id = NULL;
 	int opt82_match;
 
 	if (opt82_ses)
@@ -274,9 +275,10 @@ static struct ipoe_session *ipoe_session_lookup(struct ipoe_serv *serv, struct d
 		return ses;
 	}
 
-	if (!conf_check_mac_change || (pack->relay_agent && dhcpv4_parse_opt82(pack->relay_agent, &agent_circuit_id, &agent_remote_id))) {
+	if (!conf_check_mac_change || (pack->relay_agent && dhcpv4_parse_opt82(pack->relay_agent, &agent_circuit_id, &agent_remote_id, &subscriber_id))) {
 		agent_circuit_id = NULL;
 		agent_remote_id = NULL;
+		subscriber_id = NULL;
 	}
 
 	list_for_each_entry(ses, &serv->sessions, entry) {
@@ -1382,7 +1384,7 @@ static struct ipoe_session *ipoe_session_create_dhcpv4(struct ipoe_serv *serv, s
 		ses->relay_agent->data = (uint8_t *)(ses->relay_agent + 1);
 		memcpy(ses->relay_agent->data, pack->relay_agent->data, pack->relay_agent->len);
 		ptr += sizeof(struct dhcpv4_option) + pack->relay_agent->len;
-		if (dhcpv4_parse_opt82(ses->relay_agent, &ses->agent_circuit_id, &ses->agent_remote_id))
+		if (dhcpv4_parse_opt82(ses->relay_agent, &ses->agent_circuit_id, &ses->agent_remote_id, &ses->subscriber_id))
 			ses->relay_agent = NULL;
 	}
 
@@ -1440,6 +1442,7 @@ static void ipoe_ses_recv_dhcpv4(struct dhcpv4_serv *dhcpv4, struct dhcpv4_packe
 	int opt82_match;
 	uint8_t *agent_circuit_id = NULL;
 	uint8_t *agent_remote_id = NULL;
+	uint8_t *subscriber_id = NULL;
 
 	if (conf_verbose) {
 		log_ppp_info2("recv ");
@@ -1453,9 +1456,10 @@ static void ipoe_ses_recv_dhcpv4(struct dhcpv4_serv *dhcpv4, struct dhcpv4_packe
 		return;
 	}
 
-	if (pack->relay_agent && dhcpv4_parse_opt82(pack->relay_agent, &agent_circuit_id, &agent_remote_id)) {
+	if (pack->relay_agent && dhcpv4_parse_opt82(pack->relay_agent, &agent_circuit_id, &agent_remote_id, &subscriber_id)) {
 		agent_circuit_id = NULL;
 		agent_remote_id = NULL;
+		subscriber_id = NULL;
 	}
 
 	opt82_match = pack->relay_agent != NULL;

--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -86,6 +86,7 @@ struct ipoe_session {
 	struct dhcpv4_option *relay_agent;
 	uint8_t *agent_circuit_id;
 	uint8_t *agent_remote_id;
+	uint8_t *subscriber_id;
 	uint32_t xid;
 	uint32_t giaddr;
 	uint32_t yiaddr;

--- a/accel-pppd/ctrl/ipoe/lua.c
+++ b/accel-pppd/ctrl/ipoe/lua.c
@@ -33,6 +33,7 @@ static int packet4_option(lua_State *L);
 static int packet4_options(lua_State *L);
 static int packet4_agent_circuit_id(lua_State *L);
 static int packet4_agent_remote_id(lua_State *L);
+static int packet4_subscriber_id(lua_State *L);
 static int packet4_vlan(lua_State *L);
 static int packet4_hwaddr(lua_State *L);
 static int packet4_ipaddr(lua_State *L);
@@ -44,6 +45,7 @@ static const struct luaL_Reg packet4_lib [] = {
 	{"options", packet4_options},
 	{"agent_circuit_id", packet4_agent_circuit_id},
 	{"agent_remote_id", packet4_agent_remote_id},
+	{"subscriber_id", packet4_subscriber_id},
 	{"vlan", packet4_vlan},
 	{"hwaddr", packet4_hwaddr},
 	{"ipaddr", packet4_ipaddr},
@@ -169,6 +171,21 @@ static int packet4_agent_remote_id(lua_State *L)
 
 	if (ses->agent_remote_id)
 		lua_pushlstring(L, (char *)(ses->agent_remote_id + 1), *ses->agent_remote_id);
+	else
+		lua_pushnil(L);
+
+	return 1;
+}
+
+static int packet4_subscriber_id(lua_State *L)
+{
+	struct ipoe_session *ses = luaL_checkudata(L, 1, IPOE_PACKET4);
+
+	if (!ses || !ses->dhcpv4_request)
+		return 0;
+
+	if (ses->subscriber_id)
+		lua_pushlstring(L, (char *)(ses->subscriber_id + 1), *ses->subscriber_id);
 	else
 		lua_pushnil(L);
 


### PR DESCRIPTION
This PR adds support for DHCP Option 82 Suboption 6 (Subscriber-ID) parsing and usage in Lua Script.

Our switches can use this to add a custom defined string to the DHCP Option 82.

Currently the PR lacks support for DHCP Relay and Radius Integration, since we are not using this ourselves and I cannot test this in our setup.

Might be interesting for others.