### PR TITLE
Add serv specific ip_pool and l4_redirect_ip_pool

### DIFF
--- a/accel-pppd/ctrl/ipoe/ipoe.h
+++ b/accel-pppd/ctrl/ipoe/ipoe.h
@@ -67,6 +67,8 @@ struct ipoe_serv {
 	unsigned int opt_nat:1;
 	unsigned int opt_ipv6:1;
 	unsigned int opt_ip_unnumbered:1;
+	char *opt_ip_pool;
+	char *opt_l4_redirect_ip_pool;
 	unsigned int need_close:1;
 	unsigned int active:1;
 	unsigned int vlan_mon:1;


### PR DESCRIPTION
This PR allows to use a **l4-redirect-ip-pool** Option on interface specific configurations:

`interface=enp8s0.500,mode=L2,shared=1,start=dhcpv4,ifcfg=1,ipv6=1,ip-pool=vlan500,l4-redirect-ip-pool=noauth-vlan500`

If not specified, global l4-redirect pools are used.

In addition this patch changes the following additional things:

- remove ipv6 and dpv6 pools on l4-redirect (is this really intended/useful to have ip6 connectivity if l4-redirect is used ?!?)
- add additional log output, which ip pool is used (might be too verbosive?!?)
- unify two loglines into one on start of l4-redirect sessions

I am not fully sure if these additional changes are all ok. Especially the first one. Please comment if needed.